### PR TITLE
Fix: Address build warnings causing CI failures

### DIFF
--- a/src/components/StudyMode/StudentTools/DictionaryTool.js
+++ b/src/components/StudyMode/StudentTools/DictionaryTool.js
@@ -9,7 +9,7 @@ const CEFR_LEVELS_ORDER = importedCefrLevels || ['a0', 'a1', 'a2', 'b1', 'b2', '
 
 
 const DictionaryTool = () => {
-    const { t, language: currentUILanguage, currentLangKey } = useI18n(); // currentLangKey is 'el', 'en' etc.
+    const { t, currentLangKey } = useI18n(); // currentLangKey is 'el', 'en' etc.
     const [allVocabulary, setAllVocabulary] = useState([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(null);


### PR DESCRIPTION
- Updated vocabularyService.js to correctly load both .js and .json vocabulary files, resolving a 'Module not found' error for some English language files.
- Removed unused 'currentUILanguage' variable in DictionaryTool.js to fix an ESLint warning.

These changes should allow the CI build (where warnings are treated as errors) to pass.