### PR TITLE
Fix: Partially show freestyle day selector

### DIFF
--- a/src/components/Freestyle/FreestyleInterfaceView.js
+++ b/src/components/Freestyle/FreestyleInterfaceView.js
@@ -34,12 +34,14 @@ const FreestyleInterfaceView = ({
 
   // Determine visibility of major sections using the new logic
   // const showLanguageSelector = activePath.length === 0; // Show initially - ESLint: 'showLanguageSelector' is assigned a value but never used.
-  const showDaySelector = isMenuItemVisible(activePath, 'day_selection_stage', allMenuItemsConfig);
+  // Temporarily override showDaySelector to depend on selectedLanguage and activePath,
+  // bypassing the stubbed isMenuItemVisible for this specific component.
+  const showDaySelectorUpdated = selectedLanguage && activePath.includes('day_selection_stage');
   const showPracticeCategories = isMenuItemVisible(activePath, 'main_practice_categories_stage', allMenuItemsConfig);
-  
+
   // SubPracticeMenu visibility: if a main category is active and has children
-  const showSubPracticeMenu = currentMainCategoryKey && 
-                              activePath.includes(currentMainCategoryKey) && 
+  const showSubPracticeMenu = currentMainCategoryKey &&
+                              activePath.includes(currentMainCategoryKey) &&
                               allMenuItemsConfig[currentMainCategoryKey]?.children?.length > 0 &&
                               activePath[activePath.length -1 ] === currentMainCategoryKey;
 
@@ -54,14 +56,14 @@ const FreestyleInterfaceView = ({
     const lastItemConfig = allMenuItemsConfig[lastActiveItemKey];
     if (lastItemConfig && (!lastItemConfig.children || lastItemConfig.children.length === 0)) {
       // Check if it's not a "stage" or "action" key that shouldn't directly host an exercise
-      if (lastActiveItemKey !== 'day_selection_stage' && 
+      if (lastActiveItemKey !== 'day_selection_stage' &&
           lastActiveItemKey !== 'day_confirm_action' &&
           lastActiveItemKey !== 'main_practice_categories_stage') {
         showExerciseHost = true;
         // The subPracticeType for ExerciseHost is the key of the leaf node.
         // This might be a main category if it has no subs (e.g. practice_all_main_cat)
         // or a sub-practice item, or a sub-sub-practice item.
-        exerciseHostSubPracticeType = lastActiveItemKey; 
+        exerciseHostSubPracticeType = lastActiveItemKey;
       }
     }
   }
@@ -77,7 +79,7 @@ const FreestyleInterfaceView = ({
     <div className="freestyle-mode-container">
       <div className="main-menu-box">
         <h1 className="freestyle-mode-header" data-transliterable>COSYlanguage</h1>
-        
+
         {/* Language Selection - always show or manage via activePath if needed */}
         {/* For now, let's assume it's always available, or its onLanguageChange triggers the first onMenuSelect */}
         <div className="menu-section selector-container">
@@ -88,13 +90,13 @@ const FreestyleInterfaceView = ({
             selectedLanguage={selectedLanguage}
             onLanguageChange={onLanguageChange} // This is the wrapper from FreestyleModePage
           />
-          <ToggleLatinizationButton 
+          <ToggleLatinizationButton
             currentDisplayLanguage={selectedLanguage}
           />
         </div>
 
         {/* Day Selector */}
-        {showDaySelector && selectedLanguage && ( // Also check selectedLanguage as day selector needs it
+        {showDaySelectorUpdated && selectedLanguage && ( // Also check selectedLanguage as day selector needs it
           <div className="selector-container">
             <DaySelectorFreestyle
               currentDays={selectedDays}
@@ -114,7 +116,7 @@ const FreestyleInterfaceView = ({
           <div className="selector-container">
             <PracticeCategoryNav
               // activeCategory prop might need to be derived from activePath or currentMainCategoryKey
-              activeCategoryKey={currentMainCategoryKey} 
+              activeCategoryKey={currentMainCategoryKey}
               onMenuSelect={onMenuSelect} // Categories will call this with their itemKey
               // Pass menu logic props if PracticeCategoryNav itself needs to check visibility of its children
               activePath={activePath}
@@ -145,7 +147,7 @@ const FreestyleInterfaceView = ({
           <ExerciseHost
             subPracticeType={exerciseHostSubPracticeType} // Determined by activePath leaf
             language={selectedLanguage}
-            days={selectedDays.map(String)} 
+            days={selectedDays.map(String)}
             exerciseKey={exerciseKey} // To force re-mount/re-fetch
           />
         ) : (

--- a/src/pages/FreestyleModePage/FreestyleModePage.js
+++ b/src/pages/FreestyleModePage/FreestyleModePage.js
@@ -2,22 +2,22 @@ import React, { useState, useEffect, useCallback } from 'react'; // Removed useR
 import FreestyleInterfaceView from '../../components/Freestyle/FreestyleInterfaceView';
 import './FreestyleModePage.css';
 import { useI18n } from '../../i18n/I18nContext';
-import { 
-    getInitialMenuState, 
-    handleMenuSelection, 
-    isMenuItemVisible, 
+import {
+    getInitialMenuState,
+    handleMenuSelection,
+    isMenuItemVisible,
     allMenuItemsConfig // Imported directly, considered stable
 } from '../../utils/menuNavigationLogic';
 
 const FreestyleModePage = () => {
-  const { language: i18nLanguage, changeLanguage, t } = useI18n(); 
-  
-  const [selectedLanguage, setSelectedLanguage] = useState(i18nLanguage); 
+  const { language: i18nLanguage, changeLanguage, t } = useI18n();
+
+  const [selectedLanguage, setSelectedLanguage] = useState(i18nLanguage);
   const [selectedDays, setSelectedDays] = useState([]);
-  const [currentMainCategoryKey, setCurrentMainCategoryKey] = useState(null); 
-  const [currentSubPracticeKey, setCurrentSubPracticeKey] = useState(null);   
-  
-  const [exerciseKey, setExerciseKey] = useState(0); 
+  const [currentMainCategoryKey, setCurrentMainCategoryKey] = useState(null);
+  const [currentSubPracticeKey, setCurrentSubPracticeKey] = useState(null);
+
+  const [exerciseKey, setExerciseKey] = useState(0);
   const [toast, setToast] = useState(null);
   const [showHelp, setShowHelp] = useState(false);
 
@@ -28,7 +28,7 @@ const FreestyleModePage = () => {
     if (i18nLanguage !== selectedLanguage) {
         setSelectedLanguage(i18nLanguage);
         // Reset menu path if language changes from global context
-        setActivePath([]); 
+        setActivePath([]);
         setSelectedDays([]);
         setCurrentMainCategoryKey(null);
         setCurrentSubPracticeKey(null);
@@ -71,7 +71,7 @@ const FreestyleModePage = () => {
                 newMainCatKey = catKey;
             }
         }
-        
+
         if (newMainCatKey && newPath.length > mainCatStageIndex + 2) {
             const subKeyCandidate = newPath[mainCatStageIndex + 2];
             if (allMenuItemsConfig[subKeyCandidate]?.parent === newMainCatKey) {
@@ -85,7 +85,7 @@ const FreestyleModePage = () => {
                 }
             }
         }
-        
+
         // Update states if they have changed
         if (newMainCatKey !== currentMainCategoryKey) setCurrentMainCategoryKey(newMainCatKey);
         if (newSubPracticeKey !== currentSubPracticeKey) setCurrentSubPracticeKey(newSubPracticeKey);
@@ -95,16 +95,16 @@ const FreestyleModePage = () => {
             setCurrentMainCategoryKey(null);
             setCurrentSubPracticeKey(null);
         } else if (newMainCatKey && !newPath.includes(newMainCatKey)) {
-            setCurrentSubPracticeKey(null); 
+            setCurrentSubPracticeKey(null);
         } else if (newMainCatKey && newSubPracticeKey && !newPath.includes(newSubPracticeKey)) {
             // This case might be tricky if subPracticeKey is an exercise leaf.
             // Generally, if the path shortens such that subPracticeKey's parent is no longer the leaf, it should clear.
         }
-        
+
         if (prevActivePath.join('/') !== newPath.join('/')) {
              setExerciseKey(prev => prev + 1);
         }
-        
+
         console.log("[FreestyleModePage] New State After Select:", {days: newSelectedDays, mainCat: newMainCatKey, subPractice: newSubPracticeKey, newPath});
         return newPath;
     });
@@ -116,18 +116,18 @@ const FreestyleModePage = () => {
     if (selectedLanguage === newLanguage) return; // Avoid re-processing if language hasn't changed
 
     setSelectedLanguage(newLanguage);
-    changeLanguage(newLanguage); 
-    
+    changeLanguage(newLanguage);
+
     setSelectedDays([]);
     setCurrentMainCategoryKey(null);
     setCurrentSubPracticeKey(null);
     setExerciseKey(prevKey => prevKey + 1);
 
     // After language states are updated, set the menu path to day selection stage
-    // allMenuItemsConfig is stable and imported
-    setActivePath(handleMenuSelection([], 'day_selection_stage', allMenuItemsConfig).activePath);
-    
-    const languageName = t(`language.${newLanguage}`, newLanguage.replace('COSY', '')); 
+    // Bypassing the stubbed handleMenuSelection for now.
+    setActivePath(['day_selection_stage']);
+
+    const languageName = t(`language.${newLanguage}`, newLanguage.replace('COSY', ''));
     showToast(t('freestyle.languageChangedToast', `Language changed: ${languageName}`, { languageName }));
   };
 
@@ -135,26 +135,26 @@ const FreestyleModePage = () => {
     // This is called by DaySelectorFreestyle on every change to its internal day state.
     // It's for FreestyleModePage to be aware of the temporary selection.
     // The actual menu advancement happens when onMenuSelect is called with 'day_confirm_action'.
-    setSelectedDays(newDays); 
+    setSelectedDays(newDays);
     // No path change here directly. DaySelectorFreestyle will call onMenuSelect('day_confirm_action', {days: newDays}).
   };
-  
+
   return (
     <div className="freestyle-mode-root">
       <FreestyleInterfaceView
-        selectedLanguage={selectedLanguage} 
+        selectedLanguage={selectedLanguage}
         selectedDays={selectedDays}
-        currentMainCategoryKey={currentMainCategoryKey} 
-        currentSubPracticeKey={currentSubPracticeKey}  
+        currentMainCategoryKey={currentMainCategoryKey}
+        currentSubPracticeKey={currentSubPracticeKey}
         exerciseKey={exerciseKey}
-        
+
         activePath={activePath}
-        onMenuSelect={onMenuSelect} 
-        isMenuItemVisible={isMenuItemVisible} 
+        onMenuSelect={onMenuSelect}
+        isMenuItemVisible={isMenuItemVisible}
         allMenuItemsConfig={allMenuItemsConfig}
 
-        onLanguageChange={handleLanguageChangeWrapper} 
-        onDaysChange={handleDaysChangeWrapper} 
+        onLanguageChange={handleLanguageChangeWrapper}
+        onDaysChange={handleDaysChangeWrapper}
       />
       {toast && <div className="cosy-toast">{toast}</div>}
       <button id="floating-help-btn" onClick={() => setShowHelp(h => !h)} title={t('freestyle.helpButtonTitle', 'Help')}>?</button>


### PR DESCRIPTION
Makes the DaySelectorFreestyle component and its initial mode choice buttons visible after a language is selected in Freestyle mode.

This is achieved by:
- Modifying FreestyleInterfaceView to show the DaySelectorFreestyle component based on selectedLanguage and activePath, bypassing the currently stubbed isMenuItemVisible.
- Modifying FreestyleModePage to directly set activePath to ['day_selection_stage'] after language selection, bypassing the stubbed handleMenuSelection.

Note: Full day selection functionality (choosing a mode, selecting days, and practice category navigation) is still blocked by the placeholder/stubbed implementations in src/utils/menuNavigationLogic.js. The message "Please select day(s) and confirm." will also still appear alongside the day selector due to this.