### PR TITLE
Refactor Study Mode for students to use local JSON syllabi

### DIFF
--- a/src/components/StudyMode/LessonSectionsPanel.js
+++ b/src/components/StudyMode/LessonSectionsPanel.js
@@ -1,25 +1,30 @@
 import React from 'react';
 import { useI18n } from '../../i18n/I18nContext';
 import TransliterableText from '../Common/TransliterableText';
-import './LessonSectionsPanel.css'; 
+import './LessonSectionsPanel.css';
 
-const LessonSectionsPanel = ({ 
-  apiLessonSections = [], 
-  onSectionSelect, 
-  selectedSectionId,
-  currentLangKey // Passed from StudyModePage for consistency, though useI18n also provides it
+const LessonSectionsPanel = ({
+  sectionsFromSyllabus = null, // For students: array of { title, content_blocks, ... }
+  apiLessonSections = null,   // For teachers: array of { id, title: { lang: 'val' }, ... }
+  onSectionSelect,
+  selectedSectionId, // For student: section.title; For teacher: section.id
+  currentLangKey,    // To get teacher section titles in current language
+  isStudentMode = false,
 }) => {
-  const { t } = useI18n(); // currentLangKey from hook can also be used if not passed as prop
+  const { t } = useI18n();
 
-  const getSectionTitle = (section) => {
-    const langKeyToUse = currentLangKey || 'default'; // Fallback to 'default' if currentLangKey is undefined
+  const getTeacherSectionTitle = (section) => {
+    // Teacher sections have multilingual titles
+    const langKeyToUse = currentLangKey || 'COSYenglish'; // Fallback language
     if (section.title) {
       return section.title[langKeyToUse] || section.title.COSYenglish || section.title.default || t('lessonSectionsPanel.untitledSection', 'Untitled Section');
     }
     return t('lessonSectionsPanel.untitledSection', 'Untitled Section');
   };
 
-  if (!apiLessonSections || apiLessonSections.length === 0) {
+  const sectionsToDisplay = isStudentMode ? sectionsFromSyllabus : apiLessonSections;
+
+  if (!sectionsToDisplay || sectionsToDisplay.length === 0) {
     return (
       <div className="lesson-sections-panel">
         <h4>
@@ -38,21 +43,47 @@ const LessonSectionsPanel = ({
         <TransliterableText text={t('studyMode.lessonSectionsTitle', 'Lesson Sections')} />
       </h4>
       <ul className="sections-list">
-        {apiLessonSections.map((section) => (
-          <li 
-            key={section.id} 
-            className={`section-item ${section.id === selectedSectionId ? 'active-section' : ''}`}
-          >
-            <button 
-              onClick={() => onSectionSelect(section.id)} 
-              className="section-link-button"
-              title={getSectionTitle(section)} 
-              aria-pressed={section.id === selectedSectionId}
-            >
-              <TransliterableText text={getSectionTitle(section)} />
-            </button>
-          </li>
-        ))}
+        {sectionsToDisplay.map((section, index) => {
+          if (isStudentMode) {
+            // Student mode: section is { title, content_blocks, ... }
+            // selectedSectionId is section.title
+            const sectionTitle = section.title || t('lessonSectionsPanel.untitledSection', 'Untitled Section');
+            return (
+              <li
+                key={section.title || index} // Use title or index as key
+                className={`section-item ${sectionTitle === selectedSectionId ? 'active-section' : ''}`}
+              >
+                <button
+                  onClick={() => onSectionSelect(sectionTitle)}
+                  className="section-link-button"
+                  title={sectionTitle}
+                  aria-pressed={sectionTitle === selectedSectionId}
+                >
+                  <TransliterableText text={sectionTitle} />
+                </button>
+              </li>
+            );
+          } else {
+            // Teacher mode: section is { id, title: { lang: 'val' }, ... }
+            // selectedSectionId is section.id
+            const sectionTitle = getTeacherSectionTitle(section);
+            return (
+              <li
+                key={section.id}
+                className={`section-item ${section.id === selectedSectionId ? 'active-section' : ''}`}
+              >
+                <button
+                  onClick={() => onSectionSelect(section.id)}
+                  className="section-link-button"
+                  title={sectionTitle}
+                  aria-pressed={section.id === selectedSectionId}
+                >
+                  <TransliterableText text={sectionTitle} />
+                </button>
+              </li>
+            );
+          }
+        })}
       </ul>
     </div>
   );

--- a/src/pages/StudyModePage/StudyModePage.js
+++ b/src/pages/StudyModePage/StudyModePage.js
@@ -1,34 +1,49 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useI18n } from '../../i18n/I18nContext';
 import LanguageSelector from '../../components/LanguageSelector/LanguageSelector';
 import { useAuth } from '../../AuthContext';
-import { fetchDays } from '../../api/days';
-import { fetchLessonSections, getLessonSectionDetails } from '../../api/lessonSections';
-import RoleSelector from './RoleSelector'; 
-import StudentDashboard from './StudentDashboard'; 
-import TeacherDashboard from './TeacherDashboard'; 
-import LessonSectionsPanel from '../../components/StudyMode/LessonSectionsPanel'; 
-import ToolsPanel from '../../components/StudyMode/ToolsPanel'; 
-import TransliterableText from '../../components/Common/TransliterableText'; 
+import { fetchDays as fetchTeacherDays } from '../../api/days'; // Renamed for clarity
+import { fetchLessonSections as fetchTeacherLessonSections, getLessonSectionDetails as getTeacherLessonSectionDetails } from '../../api/lessonSections'; // For Teacher
+import { getAvailableSyllabusDays, fetchSyllabusByFileName } from '../../utils/syllabusService'; // For Student
+import RoleSelector from './RoleSelector';
+import StudentDashboard from './StudentDashboard';
+import TeacherDashboard from './TeacherDashboard';
+import LessonSectionsPanel from '../../components/StudyMode/LessonSectionsPanel';
+import ToolsPanel from '../../components/StudyMode/ToolsPanel';
+import TransliterableText from '../../components/Common/TransliterableText';
 import ToggleLatinizationButton from '../../components/Common/ToggleLatinizationButton';
 
-import './StudyModePage.css'; 
+import './StudyModePage.css';
 
 // Helper function (can be moved to a utility file if used elsewhere)
-export const getBlockElementId = (blockId) => `lesson-block-content-${blockId}`;
+// Added index as a fallback for block IDs if not present in syllabus JSON
+export const getBlockElementId = (blockId, index) => `lesson-block-content-${blockId || `gen-${index}`}`;
 
 const StudyModePage = () => {
   const { t, language, currentLangKey } = useI18n();
   const { authToken } = useAuth();
 
   const [selectedRole, setSelectedRole] = useState(() => localStorage.getItem('selectedRole') || null);
-  
-  // API Data State
+
+  // Data State
+  // For students: days = { dayNumber, lessonName, fileName }[]
+  // For teachers: days = API days results { id, title }[]
   const [days, setDays] = useState([]);
+  // For students: selectedDayId = dayNumber (string from select value)
+  // For teachers: selectedDayId = API day ID (string)
   const [selectedDayId, setSelectedDayId] = useState(null);
-  const [lessonSectionsForPanel, setLessonSectionsForPanel] = useState([]); // Sections for the LessonSectionsPanel
+
+  const [currentSyllabus, setCurrentSyllabus] = useState(null); // For students: loaded syllabus JSON
+
+  // For students: lessonSectionsForPanel = syllabusData.sections
+  // For teachers: lessonSectionsForPanel = API lesson sections results
+  const [lessonSectionsForPanel, setLessonSectionsForPanel] = useState([]);
+
+  // For students: selectedSectionId = section.title from syllabus (string)
+  // For teachers: selectedSectionId = API section ID (string)
   const [selectedSectionId, setSelectedSectionId] = useState(null);
-  const [currentExerciseBlocks, setCurrentExerciseBlocks] = useState([]); // Exercise blocks for StudentDashboard
+
+  const [currentExerciseBlocks, setCurrentExerciseBlocks] = useState([]);
 
   // UI State
   const [isLoading, setIsLoading] = useState(false);
@@ -36,70 +51,140 @@ const StudyModePage = () => {
 
   // --- Effects for Data Fetching ---
 
-  // Effect to fetch all days
+  // Effect to fetch days list based on role and current language
   useEffect(() => {
-    if (authToken) {
+    // Reset states when role or language changes significantly
+    setDays([]);
+    setSelectedDayId(null);
+    setCurrentSyllabus(null);
+    setLessonSectionsForPanel([]);
+    setSelectedSectionId(null);
+    setCurrentExerciseBlocks([]);
+    setError(null);
+
+    if (selectedRole === 'student' && currentLangKey) {
       setIsLoading(true);
-      fetchDays(authToken)
-        .then(data => {
-          setDays(data || []);
-          setError(null);
+      getAvailableSyllabusDays(currentLangKey)
+        .then(syllabusDays => {
+          setDays(syllabusDays || []);
         })
         .catch(err => {
-          console.error("Error fetching days:", err);
+          console.error("Error fetching syllabus days:", err);
           setError(t('studyModePage.errorFetchingDays', 'Failed to load study days.'));
-          setDays([]);
         })
         .finally(() => setIsLoading(false));
-    } else {
-      setDays([]); 
-      setSelectedDayId(null);
-    }
-  }, [authToken, t]);
-
-  // Effect to fetch lesson sections when a day is selected
-  useEffect(() => {
-    if (selectedDayId && authToken) {
+    } else if (selectedRole === 'teacher' && authToken) {
       setIsLoading(true);
-      fetchLessonSections(authToken, selectedDayId)
+      fetchTeacherDays(authToken) // Use renamed import
         .then(data => {
-          setLessonSectionsForPanel(data || []);
-          setError(null);
+          setDays(data || []);
         })
         .catch(err => {
-          console.error(`Error fetching sections for day ${selectedDayId}:`, err);
-          setError(t('studyModePage.errorFetchingSections', 'Failed to load lesson sections.'));
+          console.error("Error fetching teacher days:", err);
+          setError(t('studyModePage.errorFetchingDays', 'Failed to load study days.'));
+        })
+        .finally(() => setIsLoading(false));
+    }
+  }, [selectedRole, currentLangKey, authToken, t]);
+
+
+  // Effect to load lesson sections / full syllabus content when a day is selected
+  useEffect(() => {
+    // Clear previous day's data if selectedDayId is cleared or role changes to one not needing this.
+    if (!selectedDayId) {
+      setCurrentSyllabus(null);
+      setLessonSectionsForPanel([]);
+      setSelectedSectionId(null); // Also clear selected section
+      setCurrentExerciseBlocks([]); // And blocks
+      return;
+    }
+
+    if (selectedRole === 'student') {
+      // Ensure selectedDayId (string from select) is compared as number to day.dayNumber
+      const dayInfo = days.find(d => d.dayNumber === parseInt(selectedDayId));
+      if (dayInfo && dayInfo.fileName) {
+        setIsLoading(true);
+        // Clear previous day's specific data before fetching new
+        setCurrentSyllabus(null);
+        setLessonSectionsForPanel([]);
+        setSelectedSectionId(null);
+        setCurrentExerciseBlocks([]);
+
+        fetchSyllabusByFileName(dayInfo.fileName)
+          .then(syllabusData => {
+            if (syllabusData) {
+              setCurrentSyllabus(syllabusData);
+              setLessonSectionsForPanel(syllabusData.sections || []);
+              setError(null); // Clear previous errors
+            } else {
+              // This case might indicate the file was empty or not valid JSON after all
+              throw new Error(`Syllabus data for ${dayInfo.fileName} is null or not structured as expected.`);
+            }
+          })
+          .catch(err => {
+            console.error(`Error fetching or processing syllabus file ${dayInfo.fileName}:`, err);
+            setError(t('studyModePage.errorFetchingSections', 'Failed to load lesson content for the selected day.'));
+            // Ensure states are reset on error
+            setCurrentSyllabus(null);
+            setLessonSectionsForPanel([]);
+          })
+          .finally(() => setIsLoading(false));
+      }
+    } else if (selectedRole === 'teacher' && authToken && selectedDayId) {
+      setIsLoading(true);
+      // Clear previous day's specific data before fetching new
+      setLessonSectionsForPanel([]);
+      setSelectedSectionId(null);
+      setCurrentExerciseBlocks([]);
+
+      fetchTeacherLessonSections(authToken, selectedDayId) // Use renamed import for teacher data
+        .then(data => {
+          setLessonSectionsForPanel(data || []);
+          setError(null); // Clear previous errors
+        })
+        .catch(err => {
+          console.error(`Error fetching teacher sections for day ${selectedDayId}:`, err);
+          setError(t('studyModePage.errorFetchingSections', 'Failed to load lesson sections for the selected day.'));
           setLessonSectionsForPanel([]);
         })
         .finally(() => setIsLoading(false));
-    } else {
-      setLessonSectionsForPanel([]); 
-      setSelectedSectionId(null); 
     }
-  }, [selectedDayId, authToken, t]);
+  }, [selectedRole, selectedDayId, days, authToken, t]); // `days` is needed to find fileName for student
 
-  // Effect to fetch exercise blocks for the selected section (primarily for StudentDashboard)
+  // Effect to set exercise blocks when a section is selected
   useEffect(() => {
-    if (selectedSectionId && authToken && selectedRole === 'student') {
+    // Clear blocks if no section is selected or if relevant data is missing
+    if (!selectedSectionId) {
+        setCurrentExerciseBlocks([]);
+        return;
+    }
+
+    if (selectedRole === 'student' && currentSyllabus && currentSyllabus.sections) {
+      // For students, selectedSectionId is the title of the section
+      const section = currentSyllabus.sections.find(s => s.title === selectedSectionId);
+      setCurrentExerciseBlocks(section?.content_blocks || []);
+    } else if (selectedRole === 'teacher' && authToken && selectedSectionId) {
+      // For teachers, selectedSectionId is the API ID of the section
       setIsLoading(true);
-      getLessonSectionDetails(authToken, selectedSectionId)
+      getTeacherLessonSectionDetails(authToken, selectedSectionId) // Use renamed import for teacher data
         .then(data => {
           setCurrentExerciseBlocks(data.exerciseBlocks || []);
-          setError(null);
+          setError(null); // Clear previous errors
         })
         .catch(err => {
-          console.error(`Error fetching details for section ${selectedSectionId}:`, err);
+          console.error(`Error fetching teacher section details for section ${selectedSectionId}:`, err);
           setError(t('studyModePage.errorFetchingSectionContent', 'Failed to load section content.'));
           setCurrentExerciseBlocks([]);
         })
         .finally(() => setIsLoading(false));
-    } else if (selectedRole === 'student') { 
-      setCurrentExerciseBlocks([]);
+    } else if (selectedRole === 'student') {
+        // This case handles if currentSyllabus is temporarily null or sections are missing
+        setCurrentExerciseBlocks([]);
     }
-  }, [selectedSectionId, authToken, selectedRole, t]);
+  }, [selectedRole, currentSyllabus, selectedSectionId, authToken, t]);
+
 
   // --- UI Handlers and Local Storage ---
-
   useEffect(() => {
     if (selectedRole) {
       localStorage.setItem('selectedRole', selectedRole);
@@ -108,52 +193,100 @@ const StudyModePage = () => {
     }
   }, [selectedRole]);
 
-  const handleRoleSelect = (role) => {
-    setSelectedRole(prevRole => prevRole === role ? null : role);
-    setSelectedDayId(null);
+  const handleRoleSelect = useCallback((role) => {
+    setSelectedRole(prevRole => {
+      const newRole = prevRole === role ? null : role;
+      if (prevRole !== newRole) { // Reset dependent states only if role actually changes
+        setDays([]); // Will be refetched by main data fetching useEffect
+        setSelectedDayId(null);
+        setCurrentSyllabus(null);
+        setLessonSectionsForPanel([]);
+        setSelectedSectionId(null);
+        setCurrentExerciseBlocks([]);
+        setError(null);
+      }
+      return newRole;
+    });
+  }, []);
+
+  const handleDaySelectSmP = (dayIdValue) => { // dayIdValue is dayNumber (string) for students, API ID for teachers
+    setSelectedDayId(dayIdValue);
+    // Reset downstream states as new day selection invalidates current section/blocks
     setSelectedSectionId(null);
-    setLessonSectionsForPanel([]);
     setCurrentExerciseBlocks([]);
-    setError(null);
-  };
-  
-  const handleDaySelectSmP = (dayId) => {
-    setSelectedDayId(dayId);
-    setSelectedSectionId(null); 
-    setCurrentExerciseBlocks([]); 
+    if (selectedRole === 'student') {
+        // currentSyllabus and lessonSectionsForPanel will be reset and refetched by the useEffect dependent on selectedDayId
+        setCurrentSyllabus(null);
+        setLessonSectionsForPanel([]);
+    } else {
+        // For teacher, lessonSectionsForPanel also reset and refetched by its useEffect
+        setLessonSectionsForPanel([]);
+    }
   };
 
-  const handleSectionSelectSmP = (sectionId) => {
-    setSelectedSectionId(sectionId);
+  const handleSectionSelectSmP = (sectionIdentifier) => { // sectionIdentifier is title for student, ID for teacher
+    setSelectedSectionId(sectionIdentifier);
     const mainContentPanel = document.getElementById('main-content-panel');
     if (mainContentPanel) {
       mainContentPanel.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
-  
+
   const renderStudentDaySelector = () => {
-    if (selectedRole === 'student' && days.length > 0) {
-      return (
-        <div className="study-menu-section">
-          <label htmlFor="smp-day-select">
-            <TransliterableText text={t('studyModePage.selectDayLabel', 'Select Day:')} />
-          </label>
-          <select 
-            id="smp-day-select" 
-            value={selectedDayId || ""} 
-            onChange={(e) => handleDaySelectSmP(e.target.value)}
-            disabled={isLoading}
-          >
-            <option value="">{t('studyModePage.selectDayOption', '-- Select a Day --')}</option>
-            {days.map(day => (
-              <option key={day.id} value={day.id}>
-                {day.title?.[currentLangKey] || day.title?.COSYenglish || day.id}
-              </option>
-            ))}
-          </select>
-        </div>
-      );
+    // Common label for day selection
+    const daySelectLabel = <TransliterableText text={t('studyModePage.selectDayLabel', 'Select Day:')} />;
+
+    if (selectedRole === 'student') {
+      // `days` for students is { dayNumber, lessonName, fileName }[]
+      if (days.length > 0) {
+        return (
+          <div className="study-menu-section">
+            <label htmlFor="smp-student-day-select">{daySelectLabel}</label>
+            <select
+              id="smp-student-day-select"
+              value={selectedDayId || ""} // selectedDayId is dayNumber (string)
+              onChange={(e) => handleDaySelectSmP(e.target.value)}
+              disabled={isLoading}
+            >
+              <option value="">{t('studyModePage.selectDayOption', '-- Select a Day --')}</option>
+              {days.map(day => (
+                <option key={day.dayNumber} value={String(day.dayNumber)}>
+                  {`Day ${day.dayNumber}: ${day.lessonName}`}
+                </option>
+              ))}
+            </select>
+          </div>
+        );
+      } else if (!isLoading && !error) { // Show message if no days and not loading/error
+          return <div className="study-menu-section"><p>{t('studyModePage.noSyllabusDays', 'No syllabus days found for this language.')}</p></div>;
+      }
+    } else if (selectedRole === 'teacher') {
+      // `days` for teachers is API day objects {id, title}
+      if (days.length > 0) {
+        return (
+           <div className="study-menu-section">
+            <label htmlFor="smp-teacher-day-select">{daySelectLabel}</label>
+            <select
+              id="smp-teacher-day-select"
+              value={selectedDayId || ""} // selectedDayId is API day ID
+              onChange={(e) => handleDaySelectSmP(e.target.value)}
+              disabled={isLoading}
+            >
+              <option value="">{t('studyModePage.selectDayOption', '-- Select a Day --')}</option>
+              {days.map(day => (
+                <option key={day.id} value={day.id}>
+                  {day.title?.[currentLangKey] || day.title?.COSYenglish || `Day ID: ${day.id}`}
+                </option>
+              ))}
+            </select>
+          </div>
+        );
+      } else if (!isLoading && !error) { // Show message if no days and not loading/error
+          return <div className="study-menu-section"><p>{t('studyModePage.noTeacherDays', 'No days configured by teacher yet.')}</p></div>;
+      }
     }
+    // If still loading initially, or error state, the main loading/error message will cover it.
+    // Or, if selectedRole is null, nothing is rendered here.
     return null;
   };
 
@@ -162,19 +295,19 @@ const StudyModePage = () => {
       <h1>
         <TransliterableText text={t('studyMode.mainHeading', 'COSYlanguages - Study Mode')} />
       </h1>
-      
+
       <div className="study-menu-section">
         <label htmlFor="language-select" id="study-choose-language-label">
           <TransliterableText text={t('studyMode.chooseLanguageLabel', '🌎 Choose Your Language:')} />
         </label>
-        <LanguageSelector /> 
-        <ToggleLatinizationButton 
+        <LanguageSelector />
+        <ToggleLatinizationButton
           currentDisplayLanguage={currentLangKey || language}
         />
       </div>
 
       <div className="study-menu-section">
-        <label htmlFor="role-selector-buttons" id="study-choose-role-label"> 
+        <label htmlFor="role-selector-buttons" id="study-choose-role-label">
             <TransliterableText text={t('studyMode.chooseRoleLabel', '👤 Choose Your Role:')} />
         </label>
         <RoleSelector onSelectRole={handleRoleSelect} currentRole={selectedRole} />
@@ -183,8 +316,11 @@ const StudyModePage = () => {
       {renderStudentDaySelector()}
 
       {error && <p className="error-message" role="alert">{error}</p>}
-      {isLoading && !error && <p role="status"><TransliterableText text={t('loading', 'Loading...')} /></p>}
-      
+      {/* More specific loading message handling: show only if role is selected & no days yet & not an error state */}
+      {isLoading && selectedRole && (!days || days.length === 0) && !error && (
+          <p role="status"><TransliterableText text={t('loading', 'Loading...')} /></p>
+      )}
+
       <div className="study-content-area">
         {!selectedRole ? (
           <p id="study-welcome-message">
@@ -193,25 +329,49 @@ const StudyModePage = () => {
         ) : (
           <div className="dashboard-layout">
             <div className="layout-left-panel">
-              {selectedDayId ? (
-                <LessonSectionsPanel 
-                  apiLessonSections={lessonSectionsForPanel} 
-                  onSectionSelect={handleSectionSelectSmP} 
+              {selectedDayId && lessonSectionsForPanel.length > 0 ? (
+                <LessonSectionsPanel
+                  sectionsFromSyllabus={selectedRole === 'student' ? lessonSectionsForPanel : null}
+                  apiLessonSections={selectedRole === 'teacher' ? lessonSectionsForPanel : null}
+                  onSectionSelect={handleSectionSelectSmP}
                   currentLangKey={currentLangKey}
-                  selectedSectionId={selectedSectionId} 
+                  selectedSectionId={selectedSectionId}
+                  isStudentMode={selectedRole === 'student'}
                 />
-              ) : (
-                selectedRole === 'student' && !isLoading && days.length > 0 &&
-                <p><TransliterableText text={t('studyModePage.pleaseSelectDay', 'Please select a day to see lesson sections.')} /></p>
+              ) : selectedDayId && !isLoading && !error ? ( // Day selected, but no sections (or still loading them if isLoading was true)
+                <p>
+                  {selectedRole === 'student'
+                    ? t('studyModePage.noSectionsInSyllabus', 'No sections found in the syllabus for this day.')
+                    : t('studyModePage.noSectionsForTeacherDay', 'No sections configured for this day yet.')
+                  }
+                </p>
+              ) : ( // No day selected, but role is active and days are loaded (or were attempted to load)
+                selectedRole && !isLoading && days && days.length > 0 && !error && (
+                  <p>
+                    {selectedRole === 'student'
+                      ? t('studyModePage.pleaseSelectDay', 'Please select a day to see lesson sections.')
+                      : t('studyModePage.teacherPleaseSelectDay', 'Please select a day to manage its sections.')
+                    }
+                  </p>
+                )
+              )}
+              {/* This covers the case where days list itself is empty after attempting to load and no day is selected */}
+              {!isLoading && (!days || days.length === 0) && selectedRole && !error && !selectedDayId && (
+                 <p>
+                  {/* Message handled by renderStudentDaySelector or a general "no data" message if needed here */}
+                 </p>
               )}
             </div>
             <div className="layout-center-panel" id="main-content-panel">
-              {selectedRole === 'student' && 
-                <StudentDashboard 
-                  lessonBlocks={currentExerciseBlocks} 
+              {selectedRole === 'student' &&
+                <StudentDashboard
+                  lessonBlocks={currentExerciseBlocks}
                 />}
-              {selectedRole === 'teacher' && 
-                <TeacherDashboard />
+              {selectedRole === 'teacher' &&
+                <TeacherDashboard
+                  selectedDayId={selectedDayId}
+                  key={selectedDayId}
+                />
               }
             </div>
             <div className="layout-right-panel">

--- a/src/utils/syllabusService.js
+++ b/src/utils/syllabusService.js
@@ -1,0 +1,97 @@
+// src/utils/syllabusService.js
+import { fetchJsonData } from './exerciseDataService'; // Assuming this is the correct path
+
+const MAX_PROBE_DAYS = 30; // Max number of days to check for syllabus files
+
+/**
+ * Probes for available syllabus days for a given language.
+ * It checks for the existence of syllabus files like en_day1_syllabus.json.
+ * @param {string} languageCode - The language code (e.g., 'en', 'fr').
+ * @returns {Promise<Array<{ dayNumber: number, lessonName: string, fileName: string }>>} An array of available days.
+ */
+export async function getAvailableSyllabusDays(languageCode) {
+  if (!languageCode) {
+    console.error("SyllabusService: languageCode is required for getAvailableSyllabusDays.");
+    return [];
+  }
+  const availableDays = [];
+  for (let i = 1; i <= MAX_PROBE_DAYS; i++) {
+    const fileName = `${languageCode}_day${i}_syllabus.json`;
+    const filePath = `/data/custom_syllabus/${fileName}`;
+    try {
+      // We only need to know if the file exists and potentially grab the lesson name.
+      // A full fetchJsonData might be overkill if we just need existence,
+      // but it's practical here as we also want the lesson_name.
+      const { data, error } = await fetchJsonData(filePath);
+      if (!error && data && data.lesson_name) {
+        availableDays.push({
+          dayNumber: i,
+          lessonName: data.lesson_name,
+          fileName: fileName // Store fileName for easier fetching later
+        });
+      } else if (!error && data && !data.lesson_name) {
+        // File exists but no lesson_name, could be an issue or just a differently structured file.
+        // For now, we'll only include it if lesson_name is present.
+        // console.warn(`Syllabus file ${filePath} found but missing 'lesson_name'.`);
+        // Fallback: use day number as name if no lesson_name but file exists
+         availableDays.push({
+          dayNumber: i,
+          lessonName: `Day ${i} (Name TBD)`, // Fallback name
+          fileName: fileName
+        });
+      } else if (error && errorType !== 'fileNotFound' && errorType !== 'jsonError') {
+        // Log more serious errors but continue probing other days
+        // console.error(`Error probing syllabus file ${filePath}:`, error);
+      }
+      // If fileNotFound or jsonError, we just skip this day.
+    } catch (e) {
+      // Catch any unexpected errors during the fetch/parse itself
+      console.error(`Unexpected error while probing ${filePath}:`, e);
+    }
+  }
+  return availableDays;
+}
+
+/**
+ * Fetches the full syllabus content for a specific day and language.
+ * @param {string} languageCode - The language code (e.g., 'en', 'fr').
+ * @param {number|string} dayNumber - The day number to fetch.
+ * @returns {Promise<object|null>} The syllabus data object, or null if not found or error.
+ */
+export async function fetchSyllabusForDay(languageCode, dayNumber) {
+  if (!languageCode || dayNumber === undefined || dayNumber === null) {
+    console.error("SyllabusService: languageCode and dayNumber are required for fetchSyllabusForDay.");
+    return null;
+  }
+  const fileName = `${languageCode}_day${dayNumber}_syllabus.json`;
+  const filePath = `/data/custom_syllabus/${fileName}`;
+
+  const { data, error } = await fetchJsonData(filePath);
+
+  if (error) {
+    console.error(`Error fetching syllabus ${filePath}:`, error);
+    return null;
+  }
+  return data;
+}
+
+/**
+ * Fetches the syllabus content using a direct filename.
+ * Useful if the filename is already known (e.g., from getAvailableSyllabusDays).
+ * @param {string} syllabusFileName - The exact name of the syllabus file (e.g., 'en_day1_syllabus.json').
+ * @returns {Promise<object|null>} The syllabus data object, or null if not found or error.
+ */
+export async function fetchSyllabusByFileName(syllabusFileName) {
+    if (!syllabusFileName) {
+        console.error("SyllabusService: syllabusFileName is required for fetchSyllabusByFileName.");
+        return null;
+    }
+    const filePath = `/data/custom_syllabus/${syllabusFileName}`;
+    const { data, error } = await fetchJsonData(filePath);
+
+    if (error) {
+        console.error(`Error fetching syllabus ${filePath}:`, error);
+        return null;
+    }
+    return data;
+}


### PR DESCRIPTION
- Introduced `syllabusService.js` to fetch and manage syllabus data from `/public/data/custom_syllabus/`.
- Modified `StudyModePage.js` for the student role to:
  - Populate available days from local syllabus files.
  - Load selected day's syllabus JSON.
  - Pass sections and content_blocks from syllabus to child components.
- Updated `LessonSectionsPanel.js` to display sections from syllabus data when in student mode, handling section title selection.
- Adjusted `StudentDashboard.js` to correctly process `lessonBlocks` derived from syllabus JSON (using `block_type`, passing full block as `blockData`).
- Teacher role in Study Mode remains largely unchanged, continuing to use existing backend APIs for content management.
- Freestyle Mode functionality verified to be unaffected.