### PR TITLE
Refactor: Unify Button and Label components

### DIFF
--- a/src/components/Auth/Login.css
+++ b/src/components/Auth/Login.css
@@ -28,12 +28,7 @@
   margin-bottom: 20px; /* Increased margin */
 }
 
-.form-group label {
-  display: block;
-  margin-bottom: 8px; /* Increased margin */
-  font-weight: bold;
-  color: #555; /* Label color */
-}
+/* Styling for .form-group label is now handled by the Label component (unified-label class) */
 
 .form-group input[type="password"] {
   width: 100%;
@@ -45,25 +40,14 @@
 }
 
 .login-button {
-  width: 100%;
-  padding: 12px 15px; /* Adjusted padding */
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 16px; /* Consistent font size */
-  transition: background-color 0.2s ease-in-out; /* Smooth transition */
+  width: 100%; /* Specific layout style for this button */
+  padding: 12px 15px; /* Specific padding for this button, slightly larger than default .btn */
+  /* Other styles like background-color, color, border, border-radius, cursor, font-size, transition
+     are now handled by the Button component with variant="primary" and base .btn styles. */
 }
 
-.login-button:hover {
-  background-color: #0056b3;
-}
-
-.login-button:disabled {
-  background-color: #ccc;
-  cursor: not-allowed;
-}
+/* .login-button:hover is handled by .btn-primary:hover */
+/* .login-button:disabled is handled by the Button component's disabled state and global .btn:disabled styles (if any) */
 
 .error-message {
   color: #dc3545; /* Bootstrap danger color */

--- a/src/components/Auth/Login.js
+++ b/src/components/Auth/Login.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { useAuth } from '../../AuthContext'; // Adjusted path
 import { useNavigate } from 'react-router-dom';
-import './Login.css'; // We'll create this for basic styling
+import Button from '../Common/Button'; // Import Button
+import Label from '../Common/Label';   // Import Label
 import TransliterableText from '../Common/TransliterableText';
+import './Login.css';
 
 const Login = () => {
     const [pin, setPin] = useState('');
@@ -12,15 +14,13 @@ const Login = () => {
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (!pin.trim()) {
-            // setErrorState locally if preferred, or rely on authError from context
-            alert('PIN cannot be empty.'); 
+            alert('PIN cannot be empty.');
             return;
         }
         const success = await login(pin);
         if (success) {
-            navigate('/'); // Redirect to home/dashboard after successful login
+            navigate('/');
         }
-        // authError from context will display API errors
     };
 
     return (
@@ -28,7 +28,7 @@ const Login = () => {
             <form onSubmit={handleSubmit} className="login-form">
                 <h2><TransliterableText text="Teacher Login" /></h2>
                 <div className="form-group">
-                    <label htmlFor="pin"><TransliterableText text="PIN:" /></label>
+                    <Label htmlFor="pin"><TransliterableText text="PIN:" /></Label>
                     <input
                         type="password"
                         id="pin"
@@ -39,9 +39,14 @@ const Login = () => {
                     />
                 </div>
                 {authError && <p className="error-message"><TransliterableText text={authError} /></p>}
-                <button type="submit" className="login-button" disabled={loadingAuth}>
+                <Button
+                    type="submit"
+                    className="login-button"
+                    disabled={loadingAuth}
+                    variant="primary" // Assuming login button should look like a primary action
+                >
                     <TransliterableText text={loadingAuth ? 'Logging in...' : 'Login'} />
-                </button>
+                </Button>
             </form>
         </div>
     );

--- a/src/components/Common/Button.css
+++ b/src/components/Common/Button.css
@@ -1,0 +1,70 @@
+/* Button.css */
+
+/* Size modifiers */
+/* .btn-sm might be defined in index.css or here if more specific styling is needed */
+.btn-sm {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem; /* Corresponds to --font-size-sm */
+  border-radius: var(--border-radius-sm);
+}
+
+/* .btn-lg might be defined in index.css or here */
+.btn-lg {
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem; /* Corresponds to --font-size-lg */
+  border-radius: var(--border-radius-lg);
+}
+
+/* Additional custom variants if needed, for example: */
+.btn-light {
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-medium); /* Using a variable from index.css */
+  border-color: var(--color-border);
+}
+
+.btn-light:hover {
+  background-color: #d3d9df; /* Slightly darker shade of surface-medium */
+}
+
+.btn-dark {
+  color: var(--color-text-on-dark);
+  background-color: var(--color-text-headings); /* Using a dark variable */
+  border-color: var(--color-text-headings);
+}
+
+.btn-dark:hover {
+  background-color: #23272b; /* Slightly lighter shade */
+}
+
+.btn-link {
+  font-weight: 400;
+  color: var(--color-link);
+  text-decoration: none;
+  background-color: transparent;
+  border: none;
+}
+
+.btn-link:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+
+/* Custom variants for specific use cases discovered during refactoring can be added here.
+   For example, if 'toggle-latinization-btn' needs to be a variant:
+.btn-toggle-latinization {
+  padding: 8px 18px;
+  font-size: 1.1rem;
+  background: linear-gradient(90deg, #4e54c8 0%, #8f94fb 100%);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(78,84,200,0.15);
+  transition: background 0.3s, box-shadow 0.3s;
+  font-weight: 600;
+}
+
+.btn-toggle-latinization:hover {
+  background: linear-gradient(90deg, #4148b3 0%, #7c82e6 100%);
+  box-shadow: 0 4px 12px rgba(78,84,200,0.25);
+}
+*/

--- a/src/components/Common/Button.js
+++ b/src/components/Common/Button.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './Button.css'; // We'll create this for styles not covered by index.css
+
+const Button = ({
+  children,
+  onClick,
+  variant = 'default', // 'default', 'primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark', 'link'
+  size = 'md', // 'sm', 'md', 'lg'
+  type = 'button',
+  disabled = false,
+  className = '',
+  title = '',
+  ariaLabel = '',
+  ...props // To pass any other native button attributes
+}) => {
+  // Base class
+  let baseClasses = 'btn';
+
+  // Variant classes from index.css (or Button.css for more specific ones)
+  const variantClasses = {
+    default: '', // Will use .btn base style
+    primary: 'btn-primary',
+    secondary: 'btn-secondary',
+    success: 'btn-success',
+    danger: 'btn-danger',
+    warning: 'btn-warning',
+    info: 'btn-info',
+    // Assuming you might add these to index.css or Button.css if needed
+    light: 'btn-light',
+    dark: 'btn-dark',
+    link: 'btn-link',
+  };
+
+  if (variantClasses[variant]) {
+    baseClasses += ` ${variantClasses[variant]}`;
+  }
+
+  // Size classes (assuming you might add btn-sm, btn-lg to index.css or Button.css)
+  const sizeClasses = {
+    sm: 'btn-sm',
+    md: '', // Default size, no extra class needed if .btn is md by default
+    lg: 'btn-lg',
+  };
+
+  if (sizeClasses[size]) {
+    baseClasses += ` ${sizeClasses[size]}`;
+  }
+
+  // Combine with any additional classes passed via props
+  const combinedClassName = `${baseClasses} ${className}`.trim();
+
+  return (
+    <button
+      type={type}
+      className={combinedClassName}
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={ariaLabel || (typeof children === 'string' ? children : title)} // Basic accessibility for aria-label
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  variant: PropTypes.oneOf([
+    'default', 'primary', 'secondary', 'success', 'danger',
+    'warning', 'info', 'light', 'dark', 'link'
+  ]),
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  type: PropTypes.string,
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  title: PropTypes.string,
+  ariaLabel: PropTypes.string,
+};
+
+export default Button;

--- a/src/components/Common/Label.js
+++ b/src/components/Common/Label.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// No separate CSS file for Label is needed if all styling is handled by 'unified-label' in index.css
+
+const Label = ({ htmlFor, children, className = '', ...props }) => {
+  const combinedClassName = `unified-label ${className}`.trim();
+
+  return (
+    <label htmlFor={htmlFor} className={combinedClassName} {...props}>
+      {children}
+    </label>
+  );
+};
+
+Label.propTypes = {
+  htmlFor: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+export default Label;

--- a/src/components/Common/Modal.js
+++ b/src/components/Common/Modal.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import Button from './Button'; // Import the new Button component
 import './Modal.css';
 
 const Modal = ({ isOpen, onClose, title, children }) => {
@@ -27,7 +28,14 @@ const Modal = ({ isOpen, onClose, title, children }) => {
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <div className="modal-header">
                     {title && <h3 id="modal-title" className="modal-title">{title}</h3>}
-                    <button onClick={onClose} className="modal-close-button" aria-label="Close modal">&times;</button>
+                    <Button
+                        onClick={onClose}
+                        className="modal-close-button"
+                        ariaLabel="Close modal"
+                        variant="default" // Or a more specific variant if created
+                    >
+                        &times;
+                    </Button>
                 </div>
                 <div className="modal-body">
                     {children}

--- a/src/components/Common/PinModal.js
+++ b/src/components/Common/PinModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useI18n } from '../../i18n/I18nContext'; // Import useI18n for title
-import './Modal.css'; 
+import Button from './Button'; // Import the new Button component
+import './Modal.css';
 
 const PinModal = ({ onSubmit, onClose, error }) => {
   const [pin, setPin] = useState('');
@@ -21,19 +22,19 @@ const PinModal = ({ onSubmit, onClose, error }) => {
             value={pin}
             onChange={(e) => setPin(e.target.value)}
             placeholder={t('enterPinPlaceholder', 'Enter PIN')} // Added placeholder translation
-            maxLength="8" 
+            maxLength="8"
             className="pin-modal-input" // Added class for styling
           />
           {error && <p className="pin-modal-error">{error}</p>} {/* Added class for styling */}
           <div className="modal-actions pin-modal-actions"> {/* Added class & kept modal-actions for base styling */}
             {onClose && (
-                <button type="button" onClick={onClose} className="btn btn-secondary">
+                <Button type="button" onClick={onClose} variant="secondary">
                     {t('buttons.cancel', 'Cancel')}
-                </button>
+                </Button>
             )}
-            <button type="submit" className="btn btn-primary">
+            <Button type="submit" variant="primary">
               {t('buttons.submit', 'Submit')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/src/components/Common/ToggleLatinizationButton.js
+++ b/src/components/Common/ToggleLatinizationButton.js
@@ -1,32 +1,35 @@
 import React from 'react';
 import { useLatinizationContext } from '../../contexts/LatinizationContext';
 import { useI18n } from '../../i18n/I18nContext'; // Assuming useI18n provides 't' function
+import Button from './Button'; // Import the new Button component
 
 const ToggleLatinizationButton = ({ currentDisplayLanguage }) => {
   const { isLatinized, toggleLatinization, latinizableLanguageIds } = useLatinizationContext();
   const { t } = useI18n(); // For button text localization
 
-  // Determine if the button should be visible
-  // Based on whether the currentDisplayLanguage (passed as prop) is in the latinizable list
-  // The latinizableLanguageIds from context now contains the exact COSY-style language keys.
   const isCurrentLanguageLatinizable = currentDisplayLanguage && latinizableLanguageIds.includes(currentDisplayLanguage);
 
   if (!isCurrentLanguageLatinizable) {
-    return null; // Don't render the button if the current language isn't latinizable
+    return null;
   }
 
-  const buttonText = isLatinized 
-    ? (t('buttons.showOriginal', 'Show Original')) 
+  const buttonText = isLatinized
+    ? (t('buttons.showOriginal', 'Show Original'))
     : (t('buttons.showLatin', 'Show Latin'));
 
+  const buttonTitle = isLatinized
+    ? t('tooltips.showOriginalScript', 'Show text in its original script')
+    : t('tooltips.showLatinScript', 'Show text in Latin script (transliterated)');
+
   return (
-    <button
+    <Button
       onClick={toggleLatinization}
-      className="toggle-latinization-btn" // Apply the CSS class
-      title={isLatinized ? t('tooltips.showOriginalScript', 'Show text in its original script') : t('tooltips.showLatinScript', 'Show text in Latin script (transliterated)')}
+      className="toggle-latinization-btn" // Apply the specific CSS class
+      title={buttonTitle}
+      // No specific variant needed if className handles all styling
     >
       {buttonText}
-    </button>
+    </Button>
   );
 };
 

--- a/src/components/Freestyle/ExerciseControls.css
+++ b/src/components/Freestyle/ExerciseControls.css
@@ -9,77 +9,27 @@
 }
 
 .action-button {
-  padding: 10px 15px;
-  font-size: 1em; /* Relative font size */
-  border-radius: 5px;
-  border: 1px solid transparent; /* Base border */
-  cursor: pointer;
-  transition: background-color 0.2s ease-in-out, transform 0.1s ease-in-out;
-  display: inline-flex; /* Helps align emoji and text */
+  /* Styles like padding, font-size, border-radius, border, cursor, transition,
+     background-color, color are now primarily handled by the Button component's
+     base .btn style and its variants (.btn-primary, .btn-success, etc.)
+     from src/index.css. */
+
+  /* Keep flex properties for aligning content (e.g., emoji and text) within the button,
+     as .btn doesn't define these. */
+  display: inline-flex;
   align-items: center;
-  gap: 5px; /* Space between emoji and text if emoji is part of text */
-  background-color: #f8f9fa; /* Default light background */
-  color: #333; /* Default text color */
-  border-color: #ddd; /* Default border */
+  gap: 5px; /* Space between emoji/icon and text */
 }
 
-.action-button:hover:not(:disabled) {
-  opacity: 0.85;
-  transform: translateY(-1px); /* Slight lift on hover */
-}
+/* Specific button styling for background/color/border (e.g., .action-button-check,
+   .action-button-reveal, .action-button-hint, .action-button-randomize, .action-button-next)
+   and their hover/active/disabled states are now handled by the variants passed to
+   the Button component (e.g., variant="success", variant="info") and styled in src/index.css. */
 
-.action-button:active:not(:disabled) {
-  transform: translateY(0px); /* Press down effect */
-}
+/* For example, .action-button-check styling is now covered by .btn-success */
+/* .action-button-reveal styling is now covered by .btn-info */
+/* etc. */
 
-.action-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  background-color: #e9ecef; /* Slightly different background for disabled */
-}
-
-/* Specific button styling (examples, can be adjusted) */
-.action-button-check {
-  background-color: #28a745; /* Green */
-  color: white;
-  border-color: #28a745;
-}
-.action-button-check:hover:not(:disabled) {
-  background-color: #218838;
-}
-
-.action-button-reveal {
-  background-color: #17a2b8; /* Info/Teal */
-  color: white;
-  border-color: #17a2b8;
-}
-.action-button-reveal:hover:not(:disabled) {
-  background-color: #138496;
-}
-
-.action-button-hint {
-  background-color: #ffc107; /* Yellow */
-  color: #212529; /* Dark text for yellow */
-  border-color: #ffc107;
-}
-.action-button-hint:hover:not(:disabled) {
-  background-color: #e0a800;
-}
-
-.action-button-randomize {
-  background-color: #6c757d; /* Secondary/Grey */
-  color: white;
-  border-color: #6c757d;
-}
-.action-button-randomize:hover:not(:disabled) {
-  background-color: #5a6268;
-}
-
-.action-button-next {
-  background-color: #007bff; /* Primary/Blue */
-  color: white;
-  border-color: #007bff;
-}
-.action-button-next:hover:not(:disabled) {
-  background-color: #0069d9;
-}
+/* Hover, active, and disabled states are also handled by the global styles for .btn and its variants. */
+/* Any remaining specific hover/active/disabled behavior for .action-button
+   not covered by global styles would be defined here if necessary, but the goal is to rely on global styles. */

--- a/src/components/Freestyle/ExerciseControls.js
+++ b/src/components/Freestyle/ExerciseControls.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useI18n } from '../../i18n/I18nContext';
 import TransliterableText from '../Common/TransliterableText';
+import Button from '../Common/Button'; // Import Button
 import './ExerciseControls.css';
 
 const ExerciseControls = ({
@@ -16,69 +17,85 @@ const ExerciseControls = ({
 }) => {
   const { t, language: i18nLanguage } = useI18n();
 
-  // Use 'buttons.*' key pattern, assuming they exist in translation files.
-  // Default English text provided as fallback.
   const {
     showCheck = !!onCheckAnswer,
-    checkButtonText = t('buttons.check', '✔️ Check'), // Changed key
+    checkButtonText = t('buttons.check', '✔️ Check'),
     showReveal = !!onRevealAnswer,
-    revealButtonText = t('buttons.revealAnswer', '🤫 Reveal Answer'), // Changed key
+    revealButtonText = t('buttons.revealAnswer', '🤫 Reveal Answer'),
     showHint = !!onShowHint,
-    hintButtonText = t('buttons.help', '💡 Hint'), // Changed key (it.js has 'Aiuto' for help, using this as hint)
+    hintButtonText = t('buttons.help', '💡 Hint'),
     showRandomize = !!onRandomize,
-    randomizeButtonText = t('buttons.randomize', '🎲 Randomize'), // Changed key
+    randomizeButtonText = t('buttons.randomize', '🎲 Randomize'),
     showNext = !!onNextExercise,
-    nextButtonText = t('buttons.next', '➡️ Next Exercise'), // Changed key
+    nextButtonText = t('buttons.next', '➡️ Next Exercise'),
   } = config;
 
   const canInteract = !isAnswerCorrect && !isRevealed;
 
+  // Mapping exercise actions to button variants
+  // These variants (success, info, warning, secondary, primary) should correspond to styles in index.css
+  const buttonVariantMap = {
+    hint: 'warning',    // Yellowish, like hints often are
+    randomize: 'secondary', // Neutral, like randomize often is
+    check: 'success',   // Green, for correct/check
+    reveal: 'info',     // Blue/teal, for revealing information
+    next: 'primary',    // Standard primary action
+  };
+  // Retaining action-button for base styling not covered by btn/btn-variant if any
+  // And action-button-* for specific icons/text colors if variants don't cover them.
+  // Ideally, variants should cover most, and Button.css or ExerciseControls.css would handle the rest.
+
   return (
     <div className="exercise-action-buttons">
       {showHint && onShowHint && (
-        <button
-          className="action-button action-button-hint"
+        <Button
+          className="action-button action-button-hint" // Keep for potential specific styles
           onClick={onShowHint}
           disabled={!canInteract}
+          variant={buttonVariantMap.hint}
         >
           <TransliterableText text={hintButtonText} langOverride={i18nLanguage} />
-        </button>
+        </Button>
       )}
       {showRandomize && onRandomize && (
-        <button
+        <Button
           className="action-button action-button-randomize"
           onClick={onRandomize}
-          disabled={!canInteract && !showNext} 
+          disabled={!canInteract && !showNext}
+          variant={buttonVariantMap.randomize}
         >
           <TransliterableText text={randomizeButtonText} langOverride={i18nLanguage} />
-        </button>
+        </Button>
       )}
       {showCheck && onCheckAnswer && (
-        <button
+        <Button
           className="action-button action-button-check"
           onClick={onCheckAnswer}
           disabled={!canInteract}
+          variant={buttonVariantMap.check}
         >
           <TransliterableText text={checkButtonText} langOverride={i18nLanguage} />
-        </button>
+        </Button>
       )}
       {showReveal && onRevealAnswer && (
-        <button
+        <Button
           className="action-button action-button-reveal"
           onClick={onRevealAnswer}
           disabled={!canInteract}
+          variant={buttonVariantMap.reveal}
         >
           <TransliterableText text={revealButtonText} langOverride={i18nLanguage} />
-        </button>
+        </Button>
       )}
-      {customButton} 
+      {customButton}
       {showNext && onNextExercise && (
-        <button
+        <Button
           className="action-button action-button-next"
           onClick={onNextExercise}
+          variant={buttonVariantMap.next}
         >
           <TransliterableText text={nextButtonText} langOverride={i18nLanguage} />
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -17,7 +17,7 @@
 
 .header-title-area {
   /* Takes up available space, pushing nav and controls to the right if needed */
-  flex-grow: 1; 
+  flex-grow: 1;
 }
 
 .app-header h1 {
@@ -94,25 +94,15 @@
 }
 
 .logout-button {
-  background-color: #d9534f; /* Reddish color for logout */
-  color: white;
-  border: none;
-  padding: 0.4rem 0.8rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.9rem;
-  transition: background-color 0.2s ease;
+  /* background-color, color, border, border-radius, cursor, transition
+     are now handled by the Button component with variant="danger". */
+  padding: 0.4rem 0.8rem; /* Specific padding */
+  font-size: 0.9rem;      /* Specific font size */
   white-space: nowrap;
 }
 
-.logout-button:hover:not(:disabled) {
-  background-color: #c9302c;
-}
-
-.logout-button:disabled {
-  background-color: #aaa;
-  cursor: not-allowed;
-}
+/* .logout-button:hover is handled by .btn-danger:hover */
+/* .logout-button:disabled is handled by Button's disabled state and global .btn-danger:disabled (if defined) */
 
 /* Responsive adjustments for header */
 @media (max-width: 768px) {
@@ -128,11 +118,11 @@
     width: 100%; /* Full width for nav links */
     margin-top: 0.5rem;
   }
-  
+
   .app-header nav ul li {
     width: 100%;
   }
-  
+
   .app-header nav a,
   .login-link {
     display: block; /* Make links take full width */
@@ -147,7 +137,7 @@
   }
   .user-info {
     /* Ensure user info doesn't cause overflow issues */
-    flex-wrap: wrap; 
+    flex-wrap: wrap;
   }
 }
 
@@ -161,7 +151,7 @@
   .user-info {
     font-size: 0.85rem;
   }
-  .logout-button {
+  .logout-button { /* Keep responsive adjustments for logout button */
     font-size: 0.85rem;
     padding: 0.3rem 0.6rem;
   }

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { Outlet, Link, NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../AuthContext'; // Adjusted path
 import { useI18n } from '../../i18n/I18nContext'; // Import useI18n
-// import LanguageSelector from '../LanguageSelector/LanguageSelector'; // Import LanguageSelector - REMOVED
+import Button from '../Common/Button'; // Import Button
 import TransliterableText from '../Common/TransliterableText';
-import './Layout.css'; 
+import './Layout.css';
 
 const Layout = () => {
   const { isAuthenticated, currentUser, logout, loadingAuth } = useAuth();
@@ -38,13 +38,17 @@ const Layout = () => {
           </ul>
         </nav>
         <div className="header-controls">
-          {/* <LanguageSelector /> - REMOVED */}
           {isAuthenticated && currentUser && (
             <div className="user-info">
               <span><TransliterableText text={t('welcomeUser', { name: currentUser.username || currentUser.role || 'User' }) || `Welcome, ${currentUser.username || currentUser.role || 'User'}!`} /></span>
-              <button onClick={handleLogout} disabled={loadingAuth} className="logout-button">
+              <Button
+                onClick={handleLogout}
+                disabled={loadingAuth}
+                className="logout-button" // Keep for any specific layout adjustments if needed
+                variant="danger" // Using danger variant for logout
+              >
                 <TransliterableText text={loadingAuth ? (t('loggingOut') || 'Logging out...') : (t('btnLogout') || 'Logout')} />
-              </button>
+              </Button>
             </div>
           )}
           {!isAuthenticated && !loadingAuth && (

--- a/src/components/StudyMode/DayManager.css
+++ b/src/components/StudyMode/DayManager.css
@@ -26,19 +26,13 @@
     border-radius: var(--border-radius-sm);
 }
 
-.add-day-form button {
-    padding: var(--spacing-sm) var(--spacing-md);
-    background-color: var(--color-primary);
-    color: white;
-    border: none;
-    border-radius: var(--border-radius-sm);
-    cursor: pointer;
+/* Styling for the Button component within .add-day-form */
+.add-day-form .btn { /* Target the .btn class of the Button component */
+    padding: var(--spacing-sm) var(--spacing-md); /* Custom padding: 8px 16px */
+    border-radius: var(--border-radius-sm); /* Custom border-radius */
     white-space: nowrap;
-}
-
-.add-day-form button:disabled {
-    background-color: var(--color-secondary);
-    cursor: not-allowed;
+    /* background-color, color, border, cursor, disabled states
+       are handled by Button variant="primary" and global styles. */
 }
 
 .day-list {
@@ -73,35 +67,33 @@
     color: white;
     font-weight: bold;
 }
-.day-list-item.selected .day-actions button {
-    color: white; /* Make icons white on selected background */
-    border-color: rgba(255,255,255,0.5);
-}
-
 
 .day-title {
     flex-grow: 1;
     margin-right: var(--spacing-sm);
 }
 
-.day-actions button {
-    background: none;
-    border: 1px solid transparent; /* Keep layout consistent */
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    padding: var(--spacing-xs);
+/* Styling for Button components within .day-actions */
+.day-actions .btn { /* Target .btn class of Button components */
+    padding: var(--spacing-xs); /* Custom very small padding: 4px */
     margin-left: var(--spacing-xs);
-    font-size: 0.9em;
-}
-.day-actions button:hover:not(:disabled) {
-    color: var(--color-text-primary);
-    border-color: var(--color-border); /* Show border on hover */
+    /* font-size is handled by size="sm" on the Button component (0.875rem) */
+    /* background, border, color, cursor, hover/disabled states
+       are handled by Button size="sm", variant="light" and global styles. */
 }
 
-.day-actions button:disabled {
-    color: #ccc;
-    cursor: not-allowed;
+/* Specific styles for buttons (btn-rename, btn-delete might have icon color tweaks if needed) */
+/* .btn-rename, .btn-delete can be used if further distinction beyond variant="light" is required */
+
+.day-list-item.selected .day-actions .btn {
+    color: white; /* Make icons/text white on selected background */
+    border-color: rgba(255,255,255,0.5); /* Optional: Adjust border for selected state */
 }
+/* Ensure hover on selected items' buttons is also visible */
+.day-list-item.selected .day-actions .btn:hover {
+    background-color: rgba(255, 255, 255, 0.1); /* Light hover effect on selected buttons */
+}
+
 
 .error-message { /* Consistent error message styling */
     color: var(--color-danger);

--- a/src/components/StudyMode/DayManager.js
+++ b/src/components/StudyMode/DayManager.js
@@ -2,7 +2,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../../AuthContext';
 import { useI18n } from '../../i18n/I18nContext';
 import { fetchDays, addDay, updateDay, deleteDay } from '../../api/days';
-import './DayManager.css'; 
+import Button from '../Common/Button'; // Import Button
+import './DayManager.css';
 
 const DayManager = ({ onDaySelect, selectedDayId }) => {
     const { authToken } = useAuth();
@@ -37,7 +38,7 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
 
         const titleData = {
             [currentUILanguage]: newDayTitle.trim(),
-            'COSYenglish': newDayTitle.trim() 
+            'COSYenglish': newDayTitle.trim()
         };
         Object.keys(allTranslations || {}).forEach(langKey => {
             if (!titleData[langKey]) {
@@ -49,7 +50,7 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
         try {
             await addDay(authToken, { title: titleData });
             setNewDayTitle('');
-            loadDays(); 
+            loadDays();
         } catch (err) {
             setError(err.message || t('errorAddingDay') || 'Failed to add day.');
         } finally {
@@ -65,17 +66,14 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
         if (newTitlePrompt && newTitlePrompt.trim() !== "") {
             const updatedTitle = { ...currentTitleObj };
             updatedTitle[currentUILanguage] = newTitlePrompt.trim();
-            // Ensure COSYenglish is also updated if it was the one displayed or if UI lang is COSYenglish
             if (currentUILanguage === 'COSYenglish' || !updatedTitle.COSYenglish || updatedTitle.COSYenglish === currentTitleInUILang) {
                 updatedTitle.COSYenglish = newTitlePrompt.trim();
             }
-            // Propagate to other languages if they were same as old default/UI lang title
              Object.keys(allTranslations || {}).forEach(langKey => {
                 if (!updatedTitle[langKey] || updatedTitle[langKey] === currentTitleInUILang) {
                      updatedTitle[langKey] = newTitlePrompt.trim();
                 }
             });
-
 
             setIsLoading(true);
             try {
@@ -97,7 +95,7 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
             try {
                 await deleteDay(authToken, dayId);
                 if (selectedDayId === dayId) {
-                    onDaySelect(null); // Clear selection if the active day is deleted
+                    onDaySelect(null);
                 }
                 loadDays();
             } catch (err) {
@@ -107,16 +105,16 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
             }
         }
     };
-    
+
     if (!authToken) {
         return <p>{t('notAuthenticated') || 'Not authenticated.'}</p>;
     }
-    
+
     return (
         <div className="day-manager">
             <h3>{t('manageStudyDays') || 'Manage Study Days'}</h3>
             {error && <p className="error-message">{error}</p>}
-            
+
             <form onSubmit={handleAddDay} className="add-day-form">
                 <input
                     type="text"
@@ -126,13 +124,17 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
                     disabled={isLoading}
                     aria-label={t('newDayTitleAria') || "Enter title for new day"}
                 />
-                <button type="submit" disabled={isLoading || !newDayTitle.trim()}>
+                <Button
+                    type="submit"
+                    disabled={isLoading || !newDayTitle.trim()}
+                    variant="primary"
+                >
                     {isLoading && newDayTitle ? (t('addingDay') || 'Adding...') : (t('addDayBtn') || 'Add Day')}
-                </button>
+                </Button>
             </form>
 
             {isLoading && days.length === 0 && <p>{t('loadingDays') || 'Loading days...'}</p>}
-            
+
             {!isLoading && days.length === 0 && !error && (
                 <p>{t('noDaysCreatedYet') || 'No study days created yet. Add one above!'}</p>
             )}
@@ -140,21 +142,20 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
             {days.length > 0 && (
                 <ul className="day-list">
                     {days.map(day => (
-                        <li 
-                            key={day.id} 
+                        <li
+                            key={day.id}
                             className={`day-list-item ${selectedDayId === day.id ? 'selected' : ''}`}
                             onClick={(e) => {
-                                // Prevent click on day item if a button inside was clicked
-                                if (e.target.closest('.day-actions button')) return;
+                                if (e.target.closest('.day-actions button, .day-actions Button')) return; // Adjusted selector
                                 onDaySelect(day.id);
                             }}
                             onKeyDown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
-                                    if (e.target.closest('.day-actions button')) return;
+                                    if (e.target.closest('.day-actions button, .day-actions Button')) return; // Adjusted selector
                                     onDaySelect(day.id);
                                 }
                             }}
-                            tabIndex={0} // Make li focusable
+                            tabIndex={0}
                             role="button"
                             aria-pressed={selectedDayId === day.id}
                             aria-label={t('selectDayAria', { dayTitle: day.title?.[currentUILanguage] || day.title?.COSYenglish || `Day ID ${day.id}` }) || `Select day: ${day.title?.[currentUILanguage] || day.title?.COSYenglish || `Day ID ${day.id}`}`}
@@ -163,20 +164,24 @@ const DayManager = ({ onDaySelect, selectedDayId }) => {
                                 {day.title?.[currentUILanguage] || day.title?.COSYenglish || day.title || `Day ID: ${day.id}`}
                             </span>
                             <div className="day-actions">
-                                <button 
-                                    className="btn-small btn-rename" 
+                                <Button
+                                    className="btn-rename" // Keep specific class for now
+                                    size="sm"
                                     onClick={(e) => { e.stopPropagation(); handleRenameDay(day.id, day.title); }}
                                     title={t('renameDayTooltip') || "Rename day"}
-                                    aria-label={t('renameDayAria', { dayTitle: day.title?.[currentUILanguage] || day.title?.COSYenglish }) || `Rename ${day.title?.[currentUILanguage] || day.title?.COSYenglish}`}
+                                    ariaLabel={t('renameDayAria', { dayTitle: day.title?.[currentUILanguage] || day.title?.COSYenglish }) || `Rename ${day.title?.[currentUILanguage] || day.title?.COSYenglish}`}
                                     disabled={isLoading}
-                                >✏️</button>
-                                <button 
-                                    className="btn-small btn-delete" 
+                                    variant="light" // Using light as a default for icon-like buttons
+                                >✏️</Button>
+                                <Button
+                                    className="btn-delete" // Keep specific class for now
+                                    size="sm"
                                     onClick={(e) => { e.stopPropagation(); handleDeleteDay(day.id, day.title); }}
                                     title={t('deleteDayTooltip') || "Delete day"}
-                                    aria-label={t('deleteDayAria', { dayTitle: day.title?.[currentUILanguage] || day.title?.COSYenglish }) || `Delete ${day.title?.[currentUILanguage] || day.title?.COSYenglish}`}
+                                    ariaLabel={t('deleteDayAria', { dayTitle: day.title?.[currentUILanguage] || day.title?.COSYenglish }) || `Delete ${day.title?.[currentUILanguage] || day.title?.COSYenglish}`}
                                     disabled={isLoading}
-                                >🗑️</button>
+                                    variant="light" // Using light as a default for icon-like buttons
+                                >🗑️</Button>
                             </div>
                         </li>
                     ))}

--- a/src/index.css
+++ b/src/index.css
@@ -216,6 +216,93 @@ h4 { font-size: var(--font-size-h4); }
   border-color: var(--color-secondary-dark);
 }
 
+.btn-success {
+  color: var(--color-text-on-dark);
+  background-color: var(--color-success);
+  border-color: var(--color-success);
+}
+.btn-success:hover {
+  background-color: #1e7e34; /* Darker success */
+  border-color: #1c7430;
+}
+
+.btn-danger {
+  color: var(--color-text-on-dark);
+  background-color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+.btn-danger:hover {
+  background-color: #b21f2d; /* Darker danger */
+  border-color: #a71d2a;
+}
+
+.btn-warning {
+  color: var(--color-text-primary); /* Dark text for light warning */
+  background-color: var(--color-warning);
+  border-color: var(--color-warning);
+}
+.btn-warning:hover {
+  background-color: #d39e00; /* Darker warning */
+  border-color: #c69500;
+}
+
+.btn-info {
+  color: var(--color-text-on-dark);
+  background-color: var(--color-info);
+  border-color: var(--color-info);
+}
+.btn-info:hover {
+  background-color: #117a8b; /* Darker info */
+  border-color: #10707f;
+}
+
+.btn-light {
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-medium);
+  border-color: var(--color-border);
+}
+.btn-light:hover {
+  background-color: #d3d9df;
+  border-color: #c8ced3;
+}
+
+.btn-dark {
+  color: var(--color-text-on-dark);
+  background-color: var(--color-text-headings);
+  border-color: var(--color-text-headings);
+}
+.btn-dark:hover {
+  background-color: #23272b;
+  border-color: #1d2124;
+}
+
+.btn-link {
+  font-weight: 400;
+  color: var(--color-link);
+  text-decoration: none;
+  background-color: transparent;
+  border: none;
+}
+.btn-link:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+
+/* Size modifiers */
+.btn-sm {
+  padding: 0.25rem 0.5rem;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  border-radius: var(--border-radius-sm);
+}
+
+.btn-lg {
+  padding: 0.5rem 1rem;
+  font-size: var(--font-size-lg);
+  line-height: 1.5;
+  border-radius: var(--border-radius-lg);
+}
+
 /* Add more global styles or utility classes as needed */
 .text-center {
   text-align: center;


### PR DESCRIPTION
I've implemented generic Button and Label components to standardize UI elements.

- I created `src/components/Common/Button.js` with support for variants (primary, secondary, success, danger, etc.) and sizes.
- I created `src/components/Common/Label.js` using a global `unified-label` style.
- I updated `src/index.css` with standard button variant styles (.btn-primary, .btn-success, etc.) and size modifiers (.btn-sm, .btn-lg).
- I refactored existing components (Modal, PinModal, ToggleLatinizationButton, Login, ExerciseControls, Layout, DayManager) to use the new Button and Label components.
- I cleaned up and consolidated CSS in refactored components, removing redundant styles and relying on global/generic component styles where possible.
- I preserved component-specific layout or unique styles where necessary.