### PR TITLE
feat: Add interactive verb conjugation exercises

### DIFF
--- a/src/components/Freestyle/ExerciseHost.js
+++ b/src/components/Freestyle/ExerciseHost.js
@@ -22,6 +22,7 @@ import MatchImageWordExercise from './exercises/vocabulary/MatchImageWordExercis
 // import ArticleWordExercise from './exercises/grammar/ArticleWordExercise'; // Not currently in map
 // import MatchArticlesWordsExercise from './exercises/grammar/MatchArticlesWordsExercise'; // Not currently in map
 import SelectArticleExercise from './exercises/grammar/SelectArticleExercise';
+import ConjugationPracticeExercise from './exercises/grammar/ConjugationPracticeExercise'; // Added
 import TypeVerbExercise from './exercises/grammar/TypeVerbExercise'; // Not currently in map, but should be
 // import MatchVerbsPronounsExercise from './exercises/grammar/MatchVerbsPronounsExercise'; // Not currently in map
 import FillGapsExercise from './exercises/grammar/FillGapsExercise'; // Not currently in map
@@ -76,6 +77,7 @@ const exerciseMap = {
   // Grammar (ensure keys match allMenuItemsConfig if these are directly selectable)
   'grammar_fill_gaps': FillGapsExercise, // Assuming this key from config
   'grammar_type_verb': TypeVerbExercise, // Assuming this key from config
+  'grammar_conjugation_practice': ConjugationPracticeExercise, // Added
   'gender-articles': SelectArticleExercise, 
   'verbs-conjugation': WordOrderExercise, // This was likely a placeholder name for a specific type
   'word-order': WordOrderExercise, // Adding if 'word-order' is a distinct key

--- a/src/components/Freestyle/exercises/grammar/ConjugationPracticeExercise.js
+++ b/src/components/Freestyle/exercises/grammar/ConjugationPracticeExercise.js
@@ -1,0 +1,299 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { loadConjugationData } from '../../../../utils/conjugationDataService';
+import { processConjugationData } from '../../../../utils/conjugationProcessor';
+import FeedbackDisplay from '../../FeedbackDisplay';
+import ExerciseControls from '../../ExerciseControls';
+import { useI18n } from '../../../../i18n/I18nContext';
+// import useLatinization from '../../../../hooks/useLatinization'; // Might need later
+
+const ConjugationPracticeExercise = ({ language, exerciseKey }) => {
+  const [processedVerbs, setProcessedVerbs] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const { t } = useI18n();
+  // const getLatinizedText = useLatinization(); // Might need later for displaying verb infinitives etc.
+
+  const [currentExerciseMode, setCurrentExerciseMode] = useState(null); // 'fillTable', 'translateForm'
+  const [currentVerb, setCurrentVerb] = useState(null);
+  const [feedback, setFeedback] = useState({ message: '', type: '' });
+
+  // States for FillConjugationTable
+  const [isTableRevealed, setIsTableRevealed] = useState(false);
+  const [isTableAllCorrect, setIsTableAllCorrect] = useState(false);
+
+  // States for VerbFormTranslation
+  const [translationTask, setTranslationTask] = useState(null); // { tenseName, pronoun, conjugatedForm, direction }
+  const [isTranslationRevealed, setIsTranslationRevealed] = useState(false);
+  const [isTranslationCorrect, setIsTranslationCorrect] = useState(false);
+
+  // States for IrregularVerbQuiz
+  const [irregularVerbItem, setIrregularVerbItem] = useState(null); // { base, pastSimple, pastParticiple, ... }
+  const [isIrregularQuizRevealed, setIsIrregularQuizRevealed] = useState(false);
+  const [isIrregularQuizCorrect, setIsIrregularQuizCorrect] = useState(false);
+
+  const checkAnswersRef = React.useRef(null); // For child components to expose their check function
+
+  const tensesForTable = ['présent', 'futur simple', 'passé composé', 'imparfait'];
+
+  const getRandomElement = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+  const setupExercise = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setProcessedVerbs([]);
+    setCurrentExerciseMode(null);
+    setCurrentVerb(null);
+    setFeedback({ message: '', type: '' });
+
+    setIsTableRevealed(false);
+    setIsTableAllCorrect(false);
+
+    setTranslationTask(null);
+    setIsTranslationRevealed(false);
+    setIsTranslationCorrect(false);
+
+    setIrregularVerbItem(null);
+    setIsIrregularQuizRevealed(false);
+    setIsIrregularQuizCorrect(false);
+
+    if (checkAnswersRef.current) checkAnswersRef.current = null;
+
+    // Decide exercise type first
+    const exerciseTypes = ['fillTable', 'translateForm'];
+    if (language === 'COSYenglish') {
+      exerciseTypes.push('irregularEnglishVerbQuiz');
+    }
+    const chosenMode = getRandomElement(exerciseTypes);
+    // const chosenMode = language === 'COSYenglish' ? 'irregularEnglishVerbQuiz' : 'translateForm'; // TODO: Randomize later
+
+    setCurrentExerciseMode(chosenMode); // Set mode early
+
+    try {
+      if (chosenMode === 'irregularEnglishVerbQuiz' && language === 'COSYenglish') {
+        const { data: irregularVerbs, error: irregularError } = await loadEnglishIrregularVerbsData();
+        if (irregularError) throw new Error(irregularError.message || irregularError.error || t('errors.loadIrregularVerbsError', 'Failed to load irregular verbs.'));
+        if (!irregularVerbs || irregularVerbs.length === 0) {
+          setError(t('exercises.noIrregularVerbs', 'No irregular verbs found for English.'));
+          setIsLoading(false);
+          return;
+        }
+        setIrregularVerbItem(getRandomElement(irregularVerbs));
+        // No need to set processedVerbs or currentVerb for this specific mode if it doesn't use them.
+      } else { // For 'fillTable' or 'translateForm', load general conjugation data
+        const { data: rawData, error: fetchError } = await loadConjugationData(language);
+        if (fetchError) {
+          throw new Error(fetchError.message || fetchError.error || t('errors.loadConjugationDataError', 'Failed to load conjugation data.'));
+        }
+
+        if (!rawData || !rawData.verbs || rawData.verbs.length === 0) {
+          setError(t('exercises.noConjugationData', 'No conjugation data found for this language.'));
+          setIsLoading(false);
+          return;
+        }
+
+        const verbs = processConjugationData(rawData, language);
+        if (verbs.length === 0) {
+          setError(t('exercises.noProcessableConjugationData', 'No processable conjugation entries found.'));
+          setIsLoading(false);
+          return;
+        }
+        setProcessedVerbs(verbs); // Set for table or translation modes
+
+        // currentExerciseMode is already set, now populate data for that mode
+        if (currentExerciseMode === 'fillTable') {
+          const suitableVerbForTable = verbs.find(v =>
+            v.tenses && tensesForTable.some(tKey => v.tenses[tKey.toLowerCase()])
+          );
+          if (suitableVerbForTable) {
+            setCurrentVerb(suitableVerbForTable);
+          } else {
+            console.warn(`No verb found with any of the specified tenses for table: ${tensesForTable.join(', ')}.`);
+            setError(t('exercises.noSuitableVerbForTable', 'Could not find a suitable verb for the table exercise.'));
+          }
+        } else if (currentExerciseMode === 'translateForm') {
+          const verbWithTenses = verbs.filter(v => v.tenses && Object.keys(v.tenses).length > 0);
+          if (verbWithTenses.length > 0) {
+            const randomVerb = getRandomElement(verbWithTenses);
+          const availableTenses = Object.keys(randomVerb.tenses);
+          const randomTenseName = getRandomElement(availableTenses);
+          const tenseForms = randomVerb.tenses[randomTenseName]?.forms;
+
+          if (tenseForms && Object.keys(tenseForms).length > 0) {
+            const randomPronoun = getRandomElement(Object.keys(tenseForms));
+            const conjugatedForm = tenseForms[randomPronoun];
+            const direction = Math.random() < 0.5 ? 'toEnglish' : 'fromEnglish';
+
+            setCurrentVerb(randomVerb);
+            setTranslationTask({
+              tenseName: randomTenseName,
+              pronoun: randomPronoun,
+              conjugatedForm: conjugatedForm,
+              direction: direction,
+            });
+            setCurrentExerciseMode('translateForm');
+          } else {
+             console.warn(`Verb ${randomVerb.infinitive} has no forms for tense ${randomTenseName}.`);
+             setError(t('exercises.errorGeneratingTranslationTask', 'Error generating translation task.'));
+          }
+        } else {
+          setError(t('exercises.noVerbsForTranslation', 'No verbs suitable for translation exercise found.'));
+        }
+      }
+
+    } catch (err) {
+      console.error("ConjugationPracticeExercise - Error setting up:", err);
+      setError(err.message || t('errors.unexpectedError', 'An unexpected error occurred.'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [language, t]);
+
+  useEffect(() => {
+    if (language) {
+      setupExercise();
+    } else {
+      setIsLoading(false);
+      setError(t('errors.selectLang',"Please select a language."));
+    }
+  }, [language, exerciseKey, setupExercise]); // exerciseKey to re-trigger when user wants a new "session"
+
+  const handleNextExercise = () => {
+    setupExercise();
+  };
+
+  // Generic check answer handler
+  const handleCheckAnswer = () => {
+    if (checkAnswersRef.current) {
+      checkAnswersRef.current();
+    }
+  };
+
+  // Generic reveal answer handler
+  const handleRevealAnswer = () => {
+    if (currentExerciseMode === 'fillTable') {
+      setIsTableRevealed(true);
+      setIsTableAllCorrect(true);
+    } else if (currentExerciseMode === 'translateForm') {
+      setIsTranslationRevealed(true);
+      setIsTranslationCorrect(true);
+    }
+    setFeedback({ message: t('feedback.answersRevealed', 'Answers have been revealed.'), type: 'info' });
+  };
+
+  // Dynamic imports for sub-components
+  const [FillConjugationTable, setFillConjugationTable] = useState(null);
+  const [VerbFormTranslation, setVerbFormTranslation] = useState(null);
+  const [IrregularVerbQuiz, setIrregularVerbQuiz] = useState(null);
+
+
+  useEffect(() => {
+    import('./FillConjugationTable').then(module => setFillConjugationTable(() => module.default));
+    import('./VerbFormTranslation').then(module => setVerbFormTranslation(() => module.default));
+    import('./IrregularVerbQuiz').then(module => setIrregularVerbQuiz(() => module.default));
+  }, []);
+
+
+  if (isLoading) return <p>{t('loading.conjugationExercise', 'Loading conjugation exercise...')}</p>;
+  if (error) return <FeedbackDisplay message={error} type="error" />;
+
+  // Ensure sub-components are loaded before trying to render them
+  if (currentExerciseMode === 'fillTable' && !FillConjugationTable) return <p>{t('loading.exerciseComponent', 'Loading exercise component...')}</p>;
+  if (currentExerciseMode === 'translateForm' && !VerbFormTranslation) return <p>{t('loading.exerciseComponent', 'Loading exercise component...')}</p>;
+  if (currentExerciseMode === 'irregularEnglishVerbQuiz' && !IrregularVerbQuiz) return <p>{t('loading.exerciseComponent', 'Loading exercise component...')}</p>;
+
+
+  // Data availability checks
+  if (currentExerciseMode !== 'irregularEnglishVerbQuiz' && processedVerbs.length === 0 && !isLoading) {
+    return <FeedbackDisplay message={t('exercises.noConjugationDataAvailable', "No conjugation data available for practice with the current selections.")} type="info" />;
+  }
+  if (currentExerciseMode === 'irregularEnglishVerbQuiz' && !irregularVerbItem && !isLoading) {
+     return <FeedbackDisplay message={t('exercises.noIrregularVerbs', 'No irregular verbs found for English.')} type="info" />;
+  }
+
+  // Specific checks for data suitability for current mode
+  if (currentExerciseMode === 'fillTable' && !currentVerb) {
+    return <FeedbackDisplay message={t('exercises.noSuitableVerbForTable', 'Could not find a suitable verb for the table exercise with the configured tenses.')} type="info" />;
+  }
+  if (currentExerciseMode === 'translateForm' && (!currentVerb || !translationTask)) {
+     return <FeedbackDisplay message={t('exercises.errorGeneratingTranslationTask', 'Error generating translation task.')} type="info" />;
+  }
+
+
+  return (
+    <div style={{ textAlign: 'center', padding: '20px', border: '1px solid #eee', borderRadius: '8px' }}>
+      <h3>{t('titles.conjugationPractice', 'Conjugation Practice')}</h3>
+
+      <FeedbackDisplay message={feedback.message} type={feedback.type} language={language} />
+
+      {currentExerciseMode === 'fillTable' && currentVerb && FillConjugationTable && (
+        <FillConjugationTable
+          verb={currentVerb}
+          language={language}
+          tensesToShow={tensesForTable}
+          onCheckAnswers={checkAnswersRef}
+          onSetFeedback={setFeedback}
+          isRevealedExternally={isTableRevealed}
+          onSetAllCorrect={setIsTableAllCorrect}
+        />
+      )}
+
+      {currentExerciseMode === 'translateForm' && currentVerb && translationTask && VerbFormTranslation && (
+        <VerbFormTranslation
+          verb={currentVerb}
+          tenseName={translationTask.tenseName}
+          pronoun={translationTask.pronoun}
+          conjugatedForm={translationTask.conjugatedForm}
+          translationDirection={translationTask.direction}
+          language={language}
+          onCheckAnswer={checkAnswersRef}
+          onSetFeedback={setFeedback}
+          isRevealedExternally={isTranslationRevealed}
+          onSetCorrect={setIsTranslationCorrect}
+        />
+      )}
+
+      {currentExerciseMode === 'irregularEnglishVerbQuiz' && irregularVerbItem && IrregularVerbQuiz && (
+        <IrregularVerbQuiz
+          verb={irregularVerbItem}
+          language={language} // Should be COSYenglish
+          onCheckAnswer={checkAnswersRef}
+          onSetFeedback={setFeedback}
+          isRevealedExternally={isIrregularQuizRevealed}
+          onSetCorrect={setIsIrregularQuizCorrect}
+        />
+      )}
+
+      {!currentExerciseMode && ( // Fallback if no mode is active yet or component is loading
+        <div>
+          <p>{t('labels.verbsLoaded', `Successfully loaded {count} verbs for practice.`, { count: processedVerbs.length })}</p>
+          <p style={{marginTop: '20px', fontStyle: 'italic'}}>
+            {t('messages.morePracticeModesComing', 'More practice modes will be added here!')}
+          </p>
+        </div>
+      )}
+
+      <ExerciseControls
+        onCheckAnswer={!isTableAllCorrect && !isTranslationCorrect && !isIrregularQuizCorrect && !isTableRevealed && !isTranslationRevealed && !isIrregularQuizRevealed ? handleCheckAnswer : undefined}
+        onRevealAnswer={!isTableAllCorrect && !isTranslationCorrect && !isIrregularQuizCorrect && !isTableRevealed && !isTranslationRevealed && !isIrregularQuizRevealed ? handleRevealAnswer : undefined}
+        onNextExercise={handleNextExercise}
+        config={{
+          showCheck:
+            (currentExerciseMode === 'fillTable' && !isTableRevealed && !isTableAllCorrect) ||
+            (currentExerciseMode === 'translateForm' && !isTranslationRevealed && !isTranslationCorrect) ||
+            (currentExerciseMode === 'irregularEnglishVerbQuiz' && !isIrregularQuizRevealed && !isIrregularQuizCorrect),
+          showHint: false,
+          showReveal:
+            (currentExerciseMode === 'fillTable' && !isTableRevealed && !isTableAllCorrect) ||
+            (currentExerciseMode === 'translateForm' && !isTranslationRevealed && !isTranslationCorrect) ||
+            (currentExerciseMode === 'irregularEnglishVerbQuiz' && !isIrregularQuizRevealed && !isIrregularQuizCorrect),
+          showRandomize: false,
+          showNext: true,
+        }}
+        isAnswerCorrect={isTableAllCorrect || isTranslationCorrect || isIrregularQuizCorrect}
+        isRevealed={isTableRevealed || isTranslationRevealed || isIrregularQuizRevealed}
+      />
+    </div>
+  );
+};
+
+export default ConjugationPracticeExercise;

--- a/src/components/Freestyle/exercises/grammar/FillConjugationTable.js
+++ b/src/components/Freestyle/exercises/grammar/FillConjugationTable.js
@@ -1,0 +1,237 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useI18n } from '../../../../i18n/I18nContext';
+import { normalizeString } from '../../../../utils/stringUtils';
+import useLatinization from '../../../../hooks/useLatinization';
+
+// Determine common pronouns, can be expanded or made language-specific
+const getPronounsForTable = (language, verbTenses) => {
+    // Attempt to extract pronouns from the first available tense and its forms
+    if (verbTenses && Object.keys(verbTenses).length > 0) {
+        const firstTenseKey = Object.keys(verbTenses)[0];
+        const firstTense = verbTenses[firstTenseKey];
+        if (firstTense && firstTense.forms && Object.keys(firstTense.forms).length > 0) {
+            return Object.keys(firstTense.forms);
+        }
+    }
+    // Fallback pronouns if extraction fails (can be language-specific)
+    // This is a simplified list; real applications might need more robust pronoun sets per language.
+    if (language === 'COSYfrench') return ['je', 'tu', 'il/elle/on', 'nous', 'vous', 'ils/elles'];
+    if (language === 'COSYespañol') return ['yo', 'tú', 'él/ella/usted', 'nosotros', 'vosotros', 'ellos/ellas/ustedes'];
+    if (language === 'COSYenglish') return ['i', 'you', 'he/she/it', 'we', 'they'];
+    return ['pronoun1', 'pronoun2', 'pronoun3', 'pronoun4', 'pronoun5', 'pronoun6']; // Generic fallback
+};
+
+
+const FillConjugationTable = ({ verb, language, tensesToShow, onCheckAnswers, onSetFeedback, isRevealedExternally, onSetAllCorrect }) => {
+  const { t } = useI18n();
+  const getLatinizedText = useLatinization();
+
+  const [userInputs, setUserInputs] = useState({}); // Store user inputs as { 'pronoun_tense': 'value' }
+  const [solution, setSolution] = useState({}); // Store correct answers for blanked cells
+  const [prefilledCells, setPrefilledCells] = useState({}); // Store cells that are pre-filled
+  const [cellStatus, setCellStatus] = useState({}); // Store status of each cell: 'correct', 'incorrect', 'neutral'
+
+  const pronouns = useMemo(() => getPronounsForTable(language, verb.tenses), [language, verb.tenses]);
+  const activeTenses = useMemo(() => {
+    return tensesToShow.filter(tenseKey => verb.tenses[tenseKey.toLowerCase()]);
+  }, [tensesToShow, verb.tenses]);
+
+
+  useEffect(() => {
+    const newSolution = {};
+    const newPrefilled = {};
+    const initialUserInputs = {};
+    const initialCellStatus = {};
+
+    // Randomly decide which cells to make blank (e.g., 50% chance)
+    // Ensure at least one blank if possible, and not too many blanks.
+    let blankCount = 0;
+    const totalPossibleCells = pronouns.length * activeTenses.length;
+    const targetBlankCells = Math.max(1, Math.min(pronouns.length * 2, Math.floor(totalPossibleCells * 0.5))); // Aim for about 50% blanks, min 1, max 2 per pronoun avg.
+
+    const cells = [];
+    pronouns.forEach(pronoun => {
+        activeTenses.forEach(tenseKey => {
+            cells.push({pronoun, tenseKey});
+        });
+    });
+    // Shuffle cells to randomize blank selection
+    for (let i = cells.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [cells[i], cells[j]] = [cells[j], cells[i]];
+    }
+
+    cells.forEach(({pronoun, tenseKey}) => {
+        const cellKey = `${pronoun}_${tenseKey}`;
+        const tenseData = verb.tenses[tenseKey.toLowerCase()];
+        const correctAnswer = tenseData && tenseData.forms[pronoun] ? tenseData.forms[pronoun] : '';
+
+        if (correctAnswer) { // Only consider cells that should have an answer
+            if (blankCount < targetBlankCells && Math.random() < 0.65) { // Prioritize making some cells blank
+                newSolution[cellKey] = correctAnswer;
+                initialUserInputs[cellKey] = '';
+                blankCount++;
+            } else {
+                newPrefilled[cellKey] = correctAnswer;
+            }
+        }
+        initialCellStatus[cellKey] = 'neutral';
+    });
+
+    // If no blanks were made (e.g. very small table), force one if possible
+    if (blankCount === 0 && totalPossibleCells > 0) {
+        for (const {pronoun, tenseKey} of cells) {
+             const cellKey = `${pronoun}_${tenseKey}`;
+             const tenseData = verb.tenses[tenseKey.toLowerCase()];
+             const correctAnswer = tenseData && tenseData.forms[pronoun] ? tenseData.forms[pronoun] : '';
+             if (correctAnswer) {
+                newSolution[cellKey] = correctAnswer;
+                initialUserInputs[cellKey] = '';
+                delete newPrefilled[cellKey]; // Ensure it's not prefilled
+                initialCellStatus[cellKey] = 'neutral';
+                break;
+             }
+        }
+    }
+
+    setSolution(newSolution);
+    setPrefilledCells(newPrefilled);
+    setUserInputs(initialUserInputs);
+    setCellStatus(initialCellStatus);
+    if (onSetFeedback) onSetFeedback({ message: '', type: '' });
+
+  }, [verb, language, pronouns, activeTenses, onSetFeedback]);
+
+  useEffect(() => {
+      if (isRevealedExternally) {
+          const revealedInputs = {};
+          const newCellStatus = { ...cellStatus };
+          Object.keys(solution).forEach(cellKey => {
+              revealedInputs[cellKey] = solution[cellKey].split('/')[0]; // Show first answer if multiple
+              newCellStatus[cellKey] = 'revealed';
+          });
+          setUserInputs(revealedInputs);
+          setCellStatus(newCellStatus);
+      }
+  }, [isRevealedExternally, solution, cellStatus]);
+
+
+  const handleInputChange = (pronoun, tenseKey, value) => {
+    const cellKey = `${pronoun}_${tenseKey}`;
+    setUserInputs(prev => ({ ...prev, [cellKey]: value }));
+    setCellStatus(prev => ({ ...prev, [cellKey]: 'neutral' })); // Reset status on change
+    if (onSetFeedback) onSetFeedback({ message: '', type: '' });
+  };
+
+  const checkCellAnswers = () => {
+    let allCorrectInternal = true;
+    let correctCount = 0;
+    const newCellStatus = { ...cellStatus };
+
+    Object.keys(solution).forEach(cellKey => {
+      const userAns = normalizeString(userInputs[cellKey] || '');
+      const correctAnses = solution[cellKey].split('/').map(s => normalizeString(s));
+
+      if (correctAnses.includes(userAns) && userAns !== '') {
+        newCellStatus[cellKey] = 'correct';
+        correctCount++;
+      } else if (userAns === '') {
+        newCellStatus[cellKey] = 'neutral'; // Keep neutral if empty
+        allCorrectInternal = false; // Consider empty as not fully correct for overall status
+      } else {
+        newCellStatus[cellKey] = 'incorrect';
+        allCorrectInternal = false;
+      }
+    });
+    setCellStatus(newCellStatus);
+
+    if (allCorrectInternal && Object.keys(solution).length > 0 && correctCount === Object.keys(solution).length) {
+      if (onSetFeedback) onSetFeedback({ message: t('feedback.allCorrectTable', 'All filled answers are correct!'), type: 'success' });
+      if (onSetAllCorrect) onSetAllCorrect(true);
+    } else if (!allCorrectInternal && Object.keys(solution).length > 0) {
+      if (onSetFeedback) onSetFeedback({ message: t('feedback.someIncorrectTable', 'Some answers are incorrect. Please review.'), type: 'incorrect' });
+      if (onSetAllCorrect) onSetAllCorrect(false);
+    } else {
+      if (onSetFeedback) onSetFeedback({ message: '', type: '' }); // No input yet or no blanks
+    }
+    return allCorrectInternal && correctCount === Object.keys(solution).length;
+  };
+
+  // Expose checkCellAnswers via the onCheckAnswers prop from parent
+  useEffect(() => {
+    if (onCheckAnswers) {
+      onCheckAnswers.current = checkCellAnswers;
+    }
+  }, [onCheckAnswers, checkCellAnswers]);
+
+
+  if (!verb || !verb.tenses || activeTenses.length === 0) {
+    return <p>{t('loading.noTensesForVerb', 'No tenses available for this verb or tensesToShow not configured.')}</p>;
+  }
+  const latinizedInfinitive = getLatinizedText(verb.infinitive, language);
+
+  return (
+    <div style={{ margin: '20px 0' }}>
+      <h4>{t('labels.conjugateVerb', `Conjugate the verb: "${latinizedInfinitive}"` , {verbName: latinizedInfinitive} )}</h4>
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '10px' }}>
+        <thead>
+          <tr>
+            <th style={tableCellStyle(true)}>{t('labels.pronoun', 'Pronoun')}</th>
+            {activeTenses.map(tenseKey => (
+              <th key={tenseKey} style={tableCellStyle(true)}>{getLatinizedText(tenseKey.replace(/_/g, ' '), language)}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {pronouns.map(pronoun => (
+            <tr key={pronoun}>
+              <td style={tableCellStyle()}>{getLatinizedText(pronoun, language)}</td>
+              {activeTenses.map(tenseKey => {
+                const cellKey = `${pronoun}_${tenseKey}`;
+                const isBlank = cellKey in solution;
+                const prefilledValue = prefilledCells[cellKey];
+                const cellCurrentStatus = cellStatus[cellKey] || 'neutral';
+
+                return (
+                  <td key={tenseKey} style={tableCellStyle(false, cellCurrentStatus)}>
+                    {isBlank ? (
+                      <input
+                        type="text"
+                        value={userInputs[cellKey] || ''}
+                        onChange={e => handleInputChange(pronoun, tenseKey, e.target.value)}
+                        disabled={isRevealedExternally || cellCurrentStatus === 'correct'}
+                        style={{ width: '95%', padding: '8px', fontSize: '0.95rem', boxSizing: 'border-box', border: '1px solid #ccc', borderRadius: '4px', textAlign: 'center' }}
+                        aria-label={t('ariaLabels.verbFormFor', `Verb form for {pronoun} in {tense}`, {pronoun: getLatinizedText(pronoun, language), tense: getLatinizedText(tenseKey, language)})}
+                      />
+                    ) : (
+                      <span style={{ fontSize: '0.95rem' }}>{getLatinizedText(prefilledValue, language)}</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const tableCellStyle = (isHeader = false, status = 'neutral') => {
+  let style = {
+    border: '1px solid #ddd',
+    padding: '8px',
+    textAlign: 'center',
+    minWidth: '100px',
+    backgroundColor: isHeader ? '#f2f2f2' : '#fff',
+    fontWeight: isHeader ? 'bold' : 'normal',
+  };
+  if (!isHeader) {
+    if (status === 'correct') style.backgroundColor = '#d4edda'; // Greenish for correct
+    else if (status === 'incorrect') style.backgroundColor = '#f8d7da'; // Reddish for incorrect
+    else if (status === 'revealed') style.backgroundColor = '#cfe2ff'; // Bluish for revealed
+  }
+  return style;
+};
+
+export default FillConjugationTable;

--- a/src/components/Freestyle/exercises/grammar/IrregularVerbQuiz.js
+++ b/src/components/Freestyle/exercises/grammar/IrregularVerbQuiz.js
@@ -1,0 +1,171 @@
+import React, { useState, useEffect } from 'react';
+import { useI18n } from '../../../../i18n/I18nContext';
+import { normalizeString } from '../../../../utils/stringUtils';
+import useLatinization from '../../../../hooks/useLatinization'; // Though not strictly needed for English, good for consistency
+
+const IrregularVerbQuiz = ({
+  verb, // { base, pastSimple, pastParticiple, translation_en }
+  language, // Should be 'COSYenglish' for this component
+  onCheckAnswer,
+  onSetFeedback,
+  isRevealedExternally,
+  onSetCorrect
+}) => {
+  const { t } = useI18n();
+  const getLatinizedText = useLatinization(); // Using for consistency, though English won't change
+
+  const [pastSimpleInput, setPastSimpleInput] = useState('');
+  const [pastParticipleInput, setPastParticipleInput] = useState('');
+  const [isPastSimpleCorrect, setIsPastSimpleCorrect] = useState(null); // null, true, false
+  const [isPastParticipleCorrect, setIsPastParticipleCorrect] = useState(null); // null, true, false
+  const [isFullyAnswered, setIsFullyAnswered] = useState(false);
+
+
+  useEffect(() => {
+    setPastSimpleInput('');
+    setPastParticipleInput('');
+    setIsPastSimpleCorrect(null);
+    setIsPastParticipleCorrect(null);
+    setIsFullyAnswered(false);
+    if (onSetFeedback) onSetFeedback({ message: '', type: '' });
+    if (onSetCorrect) onSetCorrect(false);
+  }, [verb, onSetFeedback, onSetCorrect]);
+
+  useEffect(() => {
+    if (isRevealedExternally && !isFullyAnswered) {
+      setPastSimpleInput(verb.pastSimple.split('/')[0]);
+      setPastParticipleInput(verb.pastParticiple.split('/')[0]);
+      setIsPastSimpleCorrect(true);
+      setIsPastParticipleCorrect(true);
+      setIsFullyAnswered(true);
+      if (onSetCorrect) onSetCorrect(true);
+      if (onSetFeedback) {
+        onSetFeedback({
+          message: t('feedback.answersRevealedIrregular', `Base: {base}, Past Simple: {ps}, Past Participle: {pp}`, {
+            base: verb.base,
+            ps: verb.pastSimple,
+            pp: verb.pastParticiple,
+          }),
+          type: 'info',
+        });
+      }
+    }
+  }, [isRevealedExternally, verb, isFullyAnswered, onSetCorrect, onSetFeedback, t]);
+
+  const checkForms = () => {
+    if (isFullyAnswered && !isRevealedExternally) return;
+
+    const normalizedPSInput = normalizeString(pastSimpleInput);
+    const normalizedPPInput = normalizeString(pastParticipleInput);
+
+    const correctPastSimples = verb.pastSimple.split('/').map(s => normalizeString(s));
+    const correctPastParticiples = verb.pastParticiple.split('/').map(s => normalizeString(s));
+
+    const psCorrect = correctPastSimples.includes(normalizedPSInput);
+    const ppCorrect = correctPastParticiples.includes(normalizedPPInput);
+
+    setIsPastSimpleCorrect(psCorrect);
+    setIsPastParticipleCorrect(ppCorrect);
+
+    if (psCorrect && ppCorrect) {
+      if (onSetFeedback) onSetFeedback({ message: t('feedback.correctAllForms', 'Correct! All forms are right.'), type: 'success' });
+      if (onSetCorrect) onSetCorrect(true);
+      setIsFullyAnswered(true);
+      return true;
+    } else {
+      let messages = [];
+      if (!psCorrect && pastSimpleInput) messages.push(t('feedback.pastSimpleIncorrect', 'Past Simple is incorrect.'));
+      if (!ppCorrect && pastParticipleInput) messages.push(t('feedback.pastParticipleIncorrect', 'Past Participle is incorrect.'));
+      if (pastSimpleInput === '' || pastParticipleInput === '') messages.push(t('feedback.fillAllForms', 'Please fill in both forms.'));
+
+      if (onSetFeedback) onSetFeedback({ message: messages.join(' ') || t('feedback.tryAgain', 'Try again.'), type: 'incorrect' });
+      if (onSetCorrect) onSetCorrect(false);
+      setIsFullyAnswered(false);
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    if (onCheckAnswer) {
+      onCheckAnswer.current = checkForms;
+    }
+  }, [onCheckAnswer, checkForms]);
+
+
+  const inputGroupStyle = {
+    display: 'flex',
+    flexWrap: 'wrap', // Allow wrapping on small screens
+    alignItems: 'center',
+    justifyContent: 'center', // Center items in the flex container
+    marginBottom: '15px',
+    gap: '10px', // Gap between label and input
+  };
+
+  const labelStyle = {
+    // marginRight: '10px', // Replaced by gap
+    minWidth: '120px', // Give label some minimum width
+    textAlign: 'right', // Align text to the right for labels
+    flexBasis: '120px', // Basis for label width
+  };
+
+  const inputStyle = (isCorrect) => ({
+    padding: '8px',
+    fontSize: '1rem',
+    border: `1px solid ${isCorrect === false ? 'red' : (isCorrect === true ? 'green' : '#ccc')}`,
+    borderRadius: '4px',
+    width: 'clamp(150px, 60%, 200px)', // Responsive width
+    boxSizing: 'border-box',
+    textAlign: 'center',
+  });
+
+
+  return (
+    <div style={{ margin: '20px 0', padding: '15px', border: '1px solid #e0e0e0', borderRadius: '5px' }}>
+      <p style={{ fontWeight: 'bold', marginBottom: '20px', fontSize: '1.2em', textAlign: 'center' }}>
+        {t('labels.verbBaseForm', `Verb (Base Form):`)} {getLatinizedText(verb.base, language)}
+      </p>
+      <div style={inputGroupStyle}>
+        <label htmlFor="pastSimple" style={labelStyle}>
+          {t('labels.pastSimple', `Past Simple:`)}
+        </label>
+        <input
+          type="text"
+          id="pastSimple"
+          value={pastSimpleInput}
+          onChange={e => {
+            setPastSimpleInput(e.target.value);
+            setIsPastSimpleCorrect(null);
+            setIsFullyAnswered(false);
+            if (onSetCorrect) onSetCorrect(false);
+            if (onSetFeedback) onSetFeedback({message: '', type: ''});
+          }}
+          disabled={isFullyAnswered && !isRevealedExternally}
+          style={inputStyle(isPastSimpleCorrect)}
+          aria-label={t('ariaLabels.pastSimpleInput', "Past simple input")}
+        />
+      </div>
+      <div style={inputGroupStyle}>
+        <label htmlFor="pastParticiple" style={labelStyle}>
+          {t('labels.pastParticiple', `Past Participle:`)}
+        </label>
+        <input
+          type="text"
+          id="pastParticiple"
+          value={pastParticipleInput}
+          onChange={e => {
+            setPastParticipleInput(e.target.value);
+            setIsPastParticipleCorrect(null);
+            setIsFullyAnswered(false);
+            if (onSetCorrect) onSetCorrect(false);
+            if (onSetFeedback) onSetFeedback({message: '', type: ''});
+          }}
+          disabled={isFullyAnswered && !isRevealedExternally}
+          style={inputStyle(isPastParticipleCorrect)}
+          aria-label={t('ariaLabels.pastParticipleInput', "Past participle input")}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default IrregularVerbQuiz;

--- a/src/components/Freestyle/exercises/grammar/VerbFormTranslation.js
+++ b/src/components/Freestyle/exercises/grammar/VerbFormTranslation.js
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from 'react';
+import { useI18n } from '../../../../i18n/I18nContext';
+import { normalizeString } from '../../../../utils/stringUtils';
+import useLatinization from '../../../../hooks/useLatinization';
+
+const VerbFormTranslation = ({
+  verb, // The full verb object from processConjugationData
+  tenseName, // e.g., "présent"
+  pronoun, // e.g., "je"
+  conjugatedForm, // e.g., "vais" (the correct answer if translating from English, or part of prompt if to English)
+  translationDirection, // 'toEnglish' or 'fromEnglish'
+  language,
+  onCheckAnswer, // Callback to be triggered by parent's ExerciseControls
+  onSetFeedback, // Callback to set feedback in parent
+  isRevealedExternally, // If parent initiated reveal
+  onSetCorrect // Callback to inform parent if answer is correct
+}) => {
+  const { t } = useI18n();
+  const getLatinizedText = useLatinization();
+  const [userInput, setUserInput] = useState('');
+  const [isAnswered, setIsAnswered] = useState(false);
+
+  const infinitiveTranslation = verb.translation_en; // e.g., "to go"
+  const targetLanguageForm = conjugatedForm; // e.g., "vais"
+
+  let questionPrompt = '';
+  let correctAnswerNormalized = '';
+
+  if (translationDirection === 'toEnglish') {
+    // User sees "je vais" (for example), needs to type "to go"
+    questionPrompt = t('translate.formToEnglishPrompt', `Translate "{pronoun} {form}" to English (infinitive):`, {
+      pronoun: getLatinizedText(pronoun, language),
+      form: getLatinizedText(conjugatedForm, language),
+    });
+    correctAnswerNormalized = normalizeString(infinitiveTranslation);
+  } else { // fromEnglish
+    // User sees "to go", "je", "présent", needs to type "vais"
+    questionPrompt = t('translate.englishToFormPrompt', `What is the form of "{translation}" for "{pronoun}" in the {tenseName} tense?`, {
+      translation: infinitiveTranslation,
+      pronoun: getLatinizedText(pronoun, language),
+      tenseName: getLatinizedText(tenseName, language),
+    });
+    correctAnswerNormalized = normalizeString(targetLanguageForm);
+  }
+
+  useEffect(() => {
+    setUserInput('');
+    setIsAnswered(false);
+    if (onSetFeedback) onSetFeedback({message: '', type: ''});
+  }, [verb, tenseName, pronoun, translationDirection, onSetFeedback]);
+
+  useEffect(() => {
+    if (isRevealedExternally && !isAnswered) {
+      const answerToShow = translationDirection === 'toEnglish' ? infinitiveTranslation : targetLanguageForm.split('/')[0];
+      setUserInput(answerToShow);
+      setIsAnswered(true);
+      if (onSetCorrect) onSetCorrect(true); // Consider revealed as correct for control flow
+      if (onSetFeedback) {
+        onSetFeedback({
+          message: t('feedback.answerIs', 'The answer is: {answer}', { answer: answerToShow }),
+          type: 'info',
+        });
+      }
+    }
+  }, [isRevealedExternally, isAnswered, translationDirection, infinitiveTranslation, targetLanguageForm, onSetCorrect, onSetFeedback, t]);
+
+
+  const handleInputChange = (e) => {
+    setUserInput(e.target.value);
+    if (isAnswered) setIsAnswered(false); // Allow re-checking if user changes input after an attempt
+    if (onSetFeedback) onSetFeedback({message: '', type: ''});
+    if (onSetCorrect) onSetCorrect(false);
+  };
+
+  const checkSingleAnswer = () => {
+    if (isAnswered && userInput !== '') return; // Don't re-check if already answered correctly, unless input is cleared
+
+    const normalizedInput = normalizeString(userInput);
+    let isCorrect = false;
+
+    if (translationDirection === 'toEnglish') {
+        // infinitiveTranslation might have multiple possibilities separated by "/"
+        isCorrect = infinitiveTranslation.split('/').map(s => normalizeString(s)).includes(normalizedInput);
+    } else { // fromEnglish
+        // targetLanguageForm might have multiple possibilities separated by "/"
+        isCorrect = targetLanguageForm.split('/').map(s => normalizeString(s)).includes(normalizedInput);
+    }
+
+    if (isCorrect) {
+      if (onSetFeedback) onSetFeedback({ message: t('feedback.correct', 'Correct!'), type: 'correct' });
+      if (onSetCorrect) onSetCorrect(true);
+      setIsAnswered(true);
+    } else {
+      const actualCorrectAnswer = translationDirection === 'toEnglish'
+        ? infinitiveTranslation.split('/')[0] // Show the first option
+        : targetLanguageForm.split('/')[0];  // Show the first option
+      if (onSetFeedback) onSetFeedback({
+        message: t('feedback.incorrectAnswerIs', `Incorrect. The correct answer is: {correctAnswer}`, {correctAnswer: actualCorrectAnswer}),
+        type: 'incorrect'
+      });
+      if (onSetCorrect) onSetCorrect(false);
+      setIsAnswered(false); // Allow user to try again
+    }
+    return isCorrect;
+  };
+
+  // Expose checkSingleAnswer to parent via onCheckAnswer ref
+  useEffect(() => {
+    if (onCheckAnswer) {
+      onCheckAnswer.current = checkSingleAnswer;
+    }
+  }, [onCheckAnswer, checkSingleAnswer]);
+
+
+  return (
+    <div style={{ margin: '20px 0', padding: '15px', border: '1px solid #e0e0e0', borderRadius: '5px' }}>
+      <p style={{ fontWeight: 'bold', marginBottom: '10px' }}>{getLatinizedText(verb.infinitive, language)}</p>
+      <p style={{ marginBottom: '15px' }}>{questionPrompt}</p>
+      <input
+        type="text"
+        value={userInput}
+        onChange={handleInputChange}
+        disabled={isAnswered && userInput !== '' && !isRevealedExternally} // Disable if correctly answered, unless revealed
+        placeholder={t('placeholders.typeTranslation', "Type your answer")}
+        style={{
+          padding: '10px',
+          fontSize: '1rem',
+          width: 'clamp(200px, 80%, 300px)', // Responsive width
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          boxSizing: 'border-box'
+        }}
+        aria-label={t('ariaLabels.translationInput', "Translation input")}
+      />
+    </div>
+  );
+};
+
+export default VerbFormTranslation;

--- a/src/utils/conjugationDataService.js
+++ b/src/utils/conjugationDataService.js
@@ -1,0 +1,68 @@
+// frontend/src/utils/conjugationDataService.js
+
+// Assuming fetchJsonData and getLanguageFileKey are either duplicated here or imported
+// For now, let's duplicate the minimal needed parts if direct import is complex from here.
+
+// Minimal fetchJsonData (consider refactoring to a shared util if not already)
+async function fetchJsonData(filePath) {
+  try {
+    const fullPath = `${process.env.PUBLIC_URL || ''}${filePath}`;
+    const response = await fetch(fullPath);
+    if (response.ok) {
+      try {
+        const data = await response.json();
+        return { data, error: null, errorType: null };
+      } catch (jsonError) {
+        console.error(`Error parsing JSON from ${filePath}:`, jsonError);
+        return { data: null, error: 'Invalid JSON format', errorType: 'jsonError' };
+      }
+    } else {
+      const errorContext = `HTTP error ${response.status} while fetching ${filePath}`;
+      console.error(errorContext);
+      if (response.status === 404) {
+        return { data: null, error: `File not found: ${filePath}`, errorType: 'fileNotFound' };
+      }
+      return { data: null, error: `Failed to load data: ${errorContext}`, errorType: 'httpError' };
+    }
+  } catch (networkError) {
+    console.error(`Network error or other exception while loading data from ${filePath}:`, networkError);
+    return { data: null, error: `Network error: ${networkError.message}`, errorType: 'networkError' };
+  }
+}
+
+// Minimal langFileMap (consider refactoring to a shared util)
+const langFileMap = {
+  'COSYenglish': 'english',
+  'COSYfrench': 'french',
+  'COSYespañol': 'spanish',
+  'COSYitalian': 'italian',
+  'COSYdeutsch': 'german',
+  'COSYportugese': 'portuguese',
+  'COSYgreek': 'greek',
+  'COSYrussian': 'russian',
+  'COSYarmenian': 'armenian',
+  'COSYbrezhoneg': 'breton',
+  'COSYtatar': 'tatar',
+  'COSYbachkir': 'bashkir'
+};
+
+function getLanguageFileKey(languageIdentifier) {
+  return langFileMap[languageIdentifier] || 'english'; // Default to English
+}
+
+export async function loadConjugationData(languageIdentifier) {
+  const langKey = getLanguageFileKey(languageIdentifier);
+  const filePath = `/data/grammar/verbs/conjugations/conjugations_${langKey}.json`;
+  const { data, error, errorType } = await fetchJsonData(filePath);
+  // Conjugation data is typically an object with a "verbs" array, not filtered by day.
+  if (error) return { data: null, error, errorType }; // Return null for data on error
+  return { data, error: null, errorType: null }; // Return the whole data object
+}
+
+export async function loadEnglishIrregularVerbsData() {
+  const filePath = `/data/grammar/verbs/irregular/irregular_verbs_COSYenglish.json`;
+  const { data, error, errorType } = await fetchJsonData(filePath);
+  // irregular_verbs_COSYenglish.json is an array of objects.
+  if (error) return { data: [], error, errorType }; // Return empty array on error
+  return { data: data || [], error: null, errorType: null }; // Ensure data is an array
+}

--- a/src/utils/conjugationProcessor.js
+++ b/src/utils/conjugationProcessor.js
@@ -1,0 +1,66 @@
+// frontend/src/utils/conjugationProcessor.js
+
+/**
+ * Processes raw conjugation data to make it more accessible for exercises.
+ * @param {Object} rawConjugationData - The raw data loaded from conjugation JSON files (e.g., conjugations_french.json).
+ * @param {string} language - The current COSYlanguage code.
+ * @returns {Array<Object>} Processed and structured list of verbs with their conjugations.
+ *                          Each verb object will have:
+ *                          - infinitive: string
+ *                          - translation_en: string
+ *                          - tags: Array<string> (e.g., ["irregular", "auxiliary"])
+ *                          - verb_group: string (e.g., "-er") or null
+ *                          - tenses: Object where keys are tense names (e.g., "présent")
+ *                              and values are objects containing:
+ *                              - mood: string (e.g., "indicatif")
+ *                              - forms: Object where keys are pronouns (e.g., "je", "tu")
+ *                                       and values are the conjugated verb forms (e.g., "suis", "es").
+ *                              - (optional) auxiliary_verb: string
+ *                              - (optional) past_participle: string
+ *                              - (optional) agreement_rules: string
+ */
+export function processConjugationData(rawConjugationData, language) {
+    if (!rawConjugationData || !rawConjugationData.verbs || !Array.isArray(rawConjugationData.verbs)) {
+        console.error(`processConjugationData: Invalid rawConjugationData for language ${language}. Expected an object with a 'verbs' array. Received:`, rawConjugationData);
+        return [];
+    }
+
+    const processedVerbs = rawConjugationData.verbs.map(verb => {
+        if (!verb || typeof verb.infinitive !== 'string') {
+            console.warn(`processConjugationData: Skipping a verb entry due to missing or invalid infinitive for language ${language}. Entry:`, verb);
+            return null; // Skip this verb if essential info is missing
+        }
+
+        const processedTenses = {};
+        if (verb.tenses && typeof verb.tenses === 'object') {
+            for (const tenseName in verb.tenses) {
+                const tenseData = verb.tenses[tenseName];
+                if (tenseData && tenseData.forms && typeof tenseData.forms === 'object') {
+                    // Standardize tense names to lowercase for consistent access
+                    const standardizedTenseName = tenseName.toLowerCase();
+                    processedTenses[standardizedTenseName] = {
+                        mood: tenseData.mood || 'N/A',
+                        forms: tenseData.forms,
+                        // Conditionally add optional properties if they exist
+                        ...(tenseData.auxiliary_verb && { auxiliary_verb: tenseData.auxiliary_verb }),
+                        ...(tenseData.past_participle && { past_participle: tenseData.past_participle }),
+                        ...(tenseData.agreement_rules && { agreement_rules: tenseData.agreement_rules }),
+                    };
+                } else {
+                    // Optional: Log if a tense is malformed but still process the verb
+                    // console.warn(`processConjugationData: Tense "${tenseName}" for verb "${verb.infinitive}" in ${language} is missing 'forms' or is invalid.`, tenseData);
+                }
+            }
+        }
+
+        return {
+            infinitive: verb.infinitive,
+            translation_en: verb.translation_en || verb.infinitive, // Fallback if translation_en is missing
+            tags: Array.isArray(verb.tags) ? verb.tags : [], // Ensure tags is an array
+            verb_group: verb.verb_group || null, // Include verb_group, defaulting to null
+            tenses: processedTenses,
+        };
+    }).filter(verb => verb !== null); // Filter out any verbs that were skipped (returned as null)
+
+    return processedVerbs;
+}

--- a/src/utils/menuNavigationLogic.js
+++ b/src/utils/menuNavigationLogic.js
@@ -73,7 +73,8 @@ export const allMenuItemsConfig = {
       'grammar_fill_gaps_exercise',
       'grammar_type_verb_exercise',
       'grammar_select_article_exercise',
-      'grammar_word_order_exercise'
+      'grammar_word_order_exercise',
+      'grammar_conjugation_practice' // Added new exercise
     ]
   },
   'reading': {
@@ -114,6 +115,7 @@ export const allMenuItemsConfig = {
   'grammar_type_verb_exercise': { parent: 'grammar', isExercise: true },
   'grammar_select_article_exercise': { parent: 'grammar', isExercise: true },
   'grammar_word_order_exercise': { parent: 'grammar', isExercise: true },
+  'grammar_conjugation_practice': { parent: 'grammar', isExercise: true, i18nKey: 'subPractice.grammar.grammar_conjugation_practice' }, // Added new exercise definition
 
   // Reading Sub-Practice Exercises (Leaf nodes)
   'reading_story_exercise': { parent: 'reading', isExercise: true },


### PR DESCRIPTION
I've implemented several new interactive mini-games for practicing verb conjugations and irregular verbs, hosted within a new "Conjugation Practice" exercise in Freestyle mode.

New Mini-Games:
1.  **Fill the Conjugation Table**: You fill blank verb forms in a table for a given verb, with selected tenses and pronouns.
2.  **Verb Form Translation**: You translate a conjugated verb form to its English infinitive, or an English infinitive (with pronoun and tense) to its target language conjugated form.
3.  **Irregular Verb Quiz (English)**: You provide the Past Simple and Past Participle for a given English irregular verb base form.

Key Code Changes:
-   **Data Services (`src/utils/`)**:
    -   I created `conjugationDataService.js` with `loadConjugationData` (for full conjugation sets like `conjugations_french.json`) and `loadEnglishIrregularVerbsData` (for `irregular_verbs_COSYenglish.json`).
    -   I created `conjugationProcessor.js` with `processConjugationData` to structure loaded conjugation data for easier use in exercises.
-   **New Exercise Components (`src/components/Freestyle/exercises/grammar/`)**:
    -   `ConjugationPracticeExercise.js`: Main host component that loads data, randomly selects one of the mini-games, and manages overall exercise state.
    -   `FillConjugationTable.js`: Renders and manages the conjugation table game.
    -   `VerbFormTranslation.js`: Renders and manages the verb form translation game.
    -   `IrregularVerbQuiz.js`: Renders and manages the English irregular verb quiz.
-   **Integration into Freestyle Mode**:
    -   I updated `allMenuItemsConfig` in `src/utils/menuNavigationLogic.js` to add "Conjugation Practice" (`grammar_conjugation_practice`) under the "Grammar" category.
    -   I updated `src/components/Freestyle/ExerciseHost.js` to import and map `ConjugationPracticeExercise` to the new `grammar_conjugation_practice` key.
-   **Styling**:
    -   I added basic inline styling and responsiveness to the new exercise components for improved layout and usability.

Internationalization:
-   The new exercise appears in the menu. A corresponding i18n key (`subPractice.grammar.grammar_conjugation_practice`) should be added to translation files for proper display name.