### PR TITLE
Fix: Resolve ESLint warning in I18nContext and finalize changes

### DIFF
--- a/src/i18n/I18nContext.js
+++ b/src/i18n/I18nContext.js
@@ -95,7 +95,7 @@ export function I18nProvider({ children }) {
             translationString = tempString;
         }
         return translationString;
-    }, [language, currentTranslations]);
+    }, [currentTranslations]); // Removed 'language' dependency
 
     const getTranslationsForLang = useCallback((langKey, translationKey) => {
         if (translations && translations[langKey] && translations[langKey][translationKey] !== undefined) {


### PR DESCRIPTION
- Removed unnecessary 'language' dependency from the useCallback hook for the `t` function in I18nContext.js. This resolves the ESLint warning that was causing CI builds to fail.

This commit finalizes the work on refactoring Freestyle mode to use an island architecture, setting up Craco for multiple entry points, adding and fixing tests, and resolving various build issues. All local tests and the build process are now successful.