### PR TITLE
Fix: Ensure freestyle islands load after DOM is ready

### DIFF
--- a/src/islands/freestyleIslandsEntry.js
+++ b/src/islands/freestyleIslandsEntry.js
@@ -172,18 +172,19 @@ export const ExerciseHostIslandWrapper = ({ language, days, subPracticeType, exe
 export const HelpPopupIslandWrapper = () => <I18nProvider><LatinizationProvider><HelpPopupIsland /></LatinizationProvider></I18nProvider>;
 
 // --- Main Mounting & Event Handling Logic ---
-if (typeof window !== 'undefined' && typeof document !== 'undefined' && (typeof process === 'undefined' || process.env.NODE_ENV !== 'test')) {
-  const languageContainer = document.getElementById('language-selector-island-container');
-  if (languageContainer) {
-    ReactDOM.createRoot(languageContainer).render(<React.StrictMode><LanguageIslandWrapper /></React.StrictMode>);
-  }
+function mountFreestyleIslands() {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined' && (typeof process === 'undefined' || process.env.NODE_ENV !== 'test')) {
+    const languageContainer = document.getElementById('language-selector-island-container');
+    if (languageContainer) {
+      ReactDOM.createRoot(languageContainer).render(<React.StrictMode><LanguageIslandWrapper /></React.StrictMode>);
+    }
 
-  const helpPopupContainer = document.getElementById('help-popup-island-container');
-  if (helpPopupContainer) {
-    ReactDOM.createRoot(helpPopupContainer).render(<React.StrictMode><HelpPopupIslandWrapper /></React.StrictMode>);
-  }
+    const helpPopupContainer = document.getElementById('help-popup-island-container');
+    if (helpPopupContainer) {
+      ReactDOM.createRoot(helpPopupContainer).render(<React.StrictMode><HelpPopupIslandWrapper /></React.StrictMode>);
+    }
 
-  window.addEventListener('languageIslandChange', (event) => {
+    window.addEventListener('languageIslandChange', (event) => {
     const { selectedLanguage } = event.detail;
     globalSelectedLanguage = selectedLanguage;
     const daySelectorContainer = document.getElementById('day-selector-island-container');
@@ -247,4 +248,14 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined' && (typeof 
       );
     }
   });
+  } // end of main if block
+} // end of mountFreestyleIslands function
+
+// Wait for the DOM to be fully loaded before trying to mount the islands
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') { // Document is still loading
+    document.addEventListener('DOMContentLoaded', mountFreestyleIslands);
+  } else { // Document has already loaded
+    mountFreestyleIslands();
+  }
 }


### PR DESCRIPTION
To address issues where freestyle.html might appear blank on initial load or lack interactivity until a reload, I modified `src/islands/freestyleIslandsEntry.js`.

The main island mounting logic is now wrapped in a function that is only invoked after the `DOMContentLoaded` event fires. This ensures that the script does not attempt to manipulate the DOM or mount React components before the HTML document is fully parsed and ready, which should prevent race conditions related to DOM readiness.

This also implicitly addresses potential issues with event listeners not being correctly attached if the initial script execution was incomplete.