### PR TITLE
Feat: Add 11 new languages and implement flag backgrounds in freestyle

### DIFF
--- a/src/i18n/translationsData.js
+++ b/src/i18n/translationsData.js
@@ -291,6 +291,1623 @@ const translations = {
       backToList: "← Retour à la Liste des Decks",
       errorSetNotFoundForPlayer: "Impossible de trouver le deck à étudier. Il a peut-être été supprimé."
     }
+  },
+  COSYitaliano: {
+    languageNameInEnglish: "Italian",
+    languageNameNative: "Italiano",
+    greeting: "Hello (Italian Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  COSYespañol: {
+    languageNameInEnglish: "Spanish",
+    languageNameNative: "Español",
+    greeting: "Hello (Spanish Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  COSYportuguês: {
+    languageNameInEnglish: "Portuguese",
+    languageNameNative: "Português",
+    greeting: "Hello (Portuguese Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  COSYbrezhoneg: {
+    languageNameInEnglish: "Breton",
+    languageNameNative: "Brezhoneg",
+    greeting: "Hello (Breton Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  COSYdeutsch: {
+    languageNameInEnglish: "German",
+    languageNameNative: "Deutsch",
+    greeting: "Hello (German Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  ТАКОЙрусский: {
+    languageNameInEnglish: "Russian",
+    languageNameNative: "Русский",
+    greeting: "Hello (Russian Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  ΚΟΖΥελληνικά: {
+    languageNameInEnglish: "Greek",
+    languageNameNative: "Ελληνικά",
+    greeting: "Hello (Greek Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  ТАКОЙтатарча: {
+    languageNameInEnglish: "Tatar",
+    languageNameNative: "Татарча",
+    greeting: "Hello (Tatar Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  ТАКОЙбашҡортса: {
+    languageNameInEnglish: "Bashkir",
+    languageNameNative: "Башҡортса",
+    greeting: "Hello (Bashkir Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  ԾՈՍՅհայերեն: {
+    languageNameInEnglish: "Armenian",
+    languageNameNative: "Հայերեն",
+    greeting: "Hello (Armenian Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
+  },
+  COSYქართული: {
+    languageNameInEnglish: "Georgian",
+    languageNameNative: "ქართული",
+    greeting: "Hello (Georgian Placeholder)", // Placeholder
+    navHome: "Home",
+    navFreestyle: "Freestyle",
+    navStudyMode: "Study",
+    navMyStudySets: "My Sets",
+    selectPractice: "🧭 Choose Your Practice:",
+    selectDay: "🗓️ Select Day(s):",
+    mainHeading: "COSYlanguages",
+    loading: "Loading...",
+    saving: "Saving...",
+    cancel: "Cancel",
+    editButton: "Edit",
+    deleteButton: "Delete",
+    auth: {
+      loadingStatus: "Loading authentication status..."
+    },
+    vocabulary: "🔠 Vocabulary",
+    grammar: "🧩 Grammar",
+    sentenceSkills: "📝 Sentence Skills",
+    reading: "📚 Reading",
+    speaking: "🗣️ Speaking",
+    writing: "✍️ Writing",
+    listening: "🎧 Listening",
+    practiceAll: "🔁 Practice All",
+    subPractice: {
+      grammar: {
+        grammar_conjugation_practice: "Conjugation Practice"
+      },
+      sentenceSkills: {
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
+      }
+    },
+    sentenceUnscramble: {
+      title: "Unscramble the Sentence",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      dropWordsHere: "Click words below to build the sentence here...",
+      clickToRemoveWord: "Click to remove word"
+    },
+    fillInTheBlanks: {
+      title: "Fill in the Blanks",
+      translationLabel: "Meaning:",
+      hintLabel: "Hint:",
+      ariaLabelBlank: "Blank number {number}",
+      answersShown: "Answers are shown above."
+    },
+    controls: {
+        checkAnswer: "Check Answer",
+        revealAnswer: "Reveal Answer",
+        nextExercise: "Next Exercise",
+        tryAgain: "Try Again"
+    },
+    feedback: {
+        correct: "Correct!",
+        incorrect: "Incorrect, try again."
+    },
+    loadingExercise: "Loading exercise...",
+    loadingExercises: "Loading exercises...",
+    errors: {
+        loadDataError: "Failed to load data.",
+        exerciseHost: {
+            notFound: "Exercise type \"<strong>{subPracticeType}</strong>\" not found or not yet implemented.",
+            title: "Exercise Error",
+            suggestion: "Please check the mapping in ExerciseHost.js or select another exercise."
+        }
+    },
+    exercises: {
+        noDataForLanguage: "No exercises found for this language.",
+        allCompleted: "All exercises completed! Resetting...",
+        noExercisesAvailable: "No exercises available at the moment."
+    },
+    studySets: {
+      myTitle: "My Study Sets",
+      createNewSet: "Create New Set",
+      noSetsFound: "No study sets found. Create one to get started!",
+      itemsCount: "{count, plural, =0 {No items} one {# item} other {# items}}",
+      language: "Lang",
+      studyButton: "Study",
+      confirmDelete: "Are you sure you want to delete the study set \"{setName}\"? This action cannot be undone.",
+      deleteSuccess: "Study set \"{setName}\" deleted successfully.",
+      deleteErrorNotFound: "Could not delete \"{setName}\". Set not found.",
+      deleteErrorGeneric: "An error occurred while deleting \"{setName}\".",
+      loadError: "Failed to load study sets.",
+      navigateToCreate: "Functionality to create new set coming soon!",
+      studySetFunctionality: "Study functionality coming soon!",
+      editSetFunctionality: "Edit functionality coming soon!"
+    },
+    studySetEditor: {
+      titleEdit: "Edit Study Set",
+      titleCreate: "Create New Study Set",
+      nameLabel: "Set Name:",
+      namePlaceholder: "e.g., French Vocabulary Chapter 1",
+      descriptionLabel: "Description (Optional):",
+      descriptionPlaceholder: "A brief description of this set",
+      languageCodeLabel: "Language Code:",
+      saveChangesButton: "Save Changes",
+      createSetButton: "Create Set",
+      errorNotFound: "Study set not found.",
+      loadError: "Failed to load study set for editing.",
+      errorNameRequired: "Set name is required.",
+      saveSuccess: "Study set \"{setName}\" saved successfully!",
+      errorSaveGeneric: "Failed to save study set.",
+      cancelled: "Operation cancelled."
+    },
+    flashcardEditor: {
+      noSetId: "No study set ID provided.",
+      setNotFound: "Study set not found.",
+      loadError: "Failed to load study set for card editing.",
+      confirmDeleteCard: "Are you sure you want to delete the card \"{term1}\"?",
+      deleteCardSuccess: "Card deleted successfully.",
+      deleteCardError: "Could not delete card.",
+      errorTermsRequired: "Term 1 and Term 2 are required.",
+      updateCardSuccess: "Card updated successfully.",
+      addCardSuccess: "Card added successfully.",
+      errorSavingCard: "Failed to save card.",
+      editingTitle: "Editing Cards for: {setName}",
+      formTitleEdit: "Edit Card",
+      formTitleAdd: "Add New Card",
+      term1Label: "Term 1 (e.g., Word/Phrase):",
+      term2Label: "Term 2 (e.g., Translation/Definition):",
+      imageURILabel: "Image URL (Optional):",
+      audioURILabel: "Audio URL (Optional):",
+      exampleSentenceLabel: "Example Sentence (Optional):",
+      notesLabel: "Notes (Optional):",
+      saveCardButton: "Save Card",
+      addCardButton: "Add Card",
+      cancelEditButton: "Cancel Edit",
+      cardsListTitle: "Cards in this Set",
+      noCardsYet: "No cards in this set yet. Add one above!",
+      term1Display: "Term 1:",
+      term2Display: "Term 2:",
+      exampleDisplay: "Ex:",
+      selectSetPrompt: "Select a study set to manage its cards.",
+      doneButton: "Done Editing Cards",
+      hasImage: "(has image)",
+      hasAudio: "(has audio)"
+    },
+    myStudySetsPage: {
+      title: "Manage Your Study Sets",
+      backToList: "← Back to Set List",
+      errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
+    }
   }
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -81,7 +81,7 @@ h4 { font-size: var(--font-size-h4); }
   --color-primary-dark: #0056b3;
   --color-secondary: #6c757d;
   --color-secondary-dark: #5a6268; /* Added from old theme */
-  
+
   /* Semantic Colors */
   --color-success: #28a745; /* Main accent for success */
   --color-danger: #dc3545;  /* Main accent for danger/error */
@@ -98,7 +98,7 @@ h4 { font-size: var(--font-size-h4); }
   --color-text-secondary: #6c757d;  /* Grey text */
   --color-text-headings: #343a40;
   --color-text-on-dark: #ffffff;    /* For text on dark/primary/secondary backgrounds - matches old --text-color-light */
-  
+
   /* State Colors (Backgrounds, Text, Borders) */
   --color-success-bg: #d4edda;
   --color-success-text: #155724;
@@ -113,7 +113,7 @@ h4 { font-size: var(--font-size-h4); }
   --border-radius-md: 0.25rem;
   --border-radius-lg: 0.3rem; /* Approx 5px */
   --border-radius-xl: 12px; /* Explicitly larger for cards/modals */
-  
+
   /* Links */
   --color-link: var(--color-primary);
   --color-link-hover: var(--color-primary-dark);
@@ -121,8 +121,8 @@ h4 { font-size: var(--font-size-h4); }
   /* Typography */
   --font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  --font-family-headings: var(--font-family-base); 
-  --font-size-base: 1rem; 
+  --font-family-headings: var(--font-family-base);
+  --font-size-base: 1rem;
   --font-size-sm: 0.875rem; /* Old --font-size-small was 0.85rem */
   --font-size-lg: 1.25rem;  /* Old --font-size-large was 1.15rem */
   --font-size-h1: 2.25rem;
@@ -212,7 +212,7 @@ h4 { font-size: var(--font-size-h4); }
 
 .btn-secondary:hover {
   color: var(--color-text-on-dark);
-  background-color: var(--color-secondary-dark); 
+  background-color: var(--color-secondary-dark);
   border-color: var(--color-secondary-dark);
 }
 
@@ -332,55 +332,58 @@ body {
 }
 
 /* Individual Language Backgrounds */
-/* Ensure class names match the keys in src/i18n/translationsData.js (e.g., 'english', 'greek') */
-.english-bg { /* Key: english */
+/* Class names now match the keys in src/i18n/translationsData.js */
+.COSYenglish-bg {
   background-image: url('https://flagcdn.com/gb.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.french-bg { /* Key: french */
+.COSYfrench-bg {
   background-image: url('https://flagcdn.com/fr.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.russian-bg { /* Key: russian */
+.ТАКОЙрусский-bg {
   background-image: url('https://flagcdn.com/ru.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.italian-bg { /* Key: italian */
+.COSYitaliano-bg {
   background-image: url('https://flagcdn.com/it.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.spanish-bg { /* Key: spanish */
+.COSYespañol-bg {
   background-image: url('https://flagcdn.com/es.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.german-bg { /* Key: german */
+.COSYdeutsch-bg {
   background-image: url('https://flagcdn.com/de.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.armenian-bg { /* Key: armenian */
+.ԾՈՍՅհայերեն-bg { /* Armenian */
   background-image: url('https://flagcdn.com/am.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-/* Languages with local flags - paths might need adjustment based on project structure */
-/* Assuming assets are in public folder, so /assets/icons/ is relative to public URL */
-.bashkir-bg { /* Key: bashkir */
-  background-image: url('/public/assets/icons/Flag_of_Bashkortostan.png'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+/* Local flags - paths corrected to be relative to public root */
+.ТАКОЙбашҡортса-bg { /* Bashkir */
+  background-image: url('/assets/icons/Flag_of_Bashkortostan.png'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.tatar-bg { /* Key: tatar */
-  background-image: url('/public/assets/icons/Flag_of_Tatarstan.png'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+.ТАКОЙтатарча-bg { /* Tatar */
+  background-image: url('/assets/icons/Flag_of_Tatarstan.png'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.breton-bg { /* Key: breton */
-  background-image: url('/public/assets/icons/Flag_of_Brittany.png'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+.COSYbrezhoneg-bg { /* Breton */
+  background-image: url('/assets/icons/Flag_of_Brittany.png'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.greek-bg { /* Key: greek */
+.ΚΟΖΥελληνικά-bg { /* Greek */
   background-image: url('https://flagcdn.com/gr.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-.portuguese-bg { /* Key: portuguese */
+.COSYportuguês-bg { /* Portuguese */
   background-image: url('https://flagcdn.com/pt.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+}
+
+.COSYქართული-bg { /* Georgian */
+  background-image: url('https://flagcdn.com/ge.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
 /* Fallback for unknown language backgrounds */


### PR DESCRIPTION
- Updated src/i18n/translationsData.js to include configurations for: Italian, Spanish, Portuguese, Breton, German, Russian, Greek, Tatar, Bashkir, Armenian, and Georgian, ensuring all 13 target languages are available in the freestyle language selector. Placeholder English translations are used for new languages pending full localization.

- Updated src/index.css:
  - Corrected CSS class names for language flag backgrounds to align with the i18n keys (e.g., .COSYenglish-bg, .ТАКОЙрусский-bg).
  - Fixed paths for locally stored flag images (Bashkir, Tatar, Breton) to correctly point to /assets/icons/.
  - Added a new CSS rule for the Georgian flag using flagcdn.com.

- This ensures that selecting any of the 13 languages in freestyle mode will now display the corresponding national flag as the page background.