### PR TITLE
I tried to fix local flag paths in CSS using relative paths.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -361,17 +361,17 @@ body {
   background-image: url('https://flagcdn.com/am.svg'), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
-/* Local flags - paths corrected to use %PUBLIC_URL% */
+/* Local flags - paths corrected to be relative from src/ to public/ */
 .ТАКОЙбашҡортса-bg { /* Bashkir */
-  background-image: url(%PUBLIC_URL%/assets/icons/Flag_of_Bashkortostan.png), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+  background-image: url(../public/assets/icons/Flag_of_Bashkortostan.png), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
 .ТАКОЙтатарча-bg { /* Tatar */
-  background-image: url(%PUBLIC_URL%/assets/icons/Flag_of_Tatarstan.png), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+  background-image: url(../public/assets/icons/Flag_of_Tatarstan.png), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
 .COSYbrezhoneg-bg { /* Breton */
-  background-image: url(%PUBLIC_URL%/assets/icons/Flag_of_Brittany.png), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
+  background-image: url(../public/assets/icons/Flag_of_Brittany.png), linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%) !important;
 }
 
 .ΚΟΖΥελληνικά-bg { /* Greek */


### PR DESCRIPTION
I updated src/index.css to use relative paths (e.g., ../public/assets/icons/Flag_of_Bashkortostan.png) for local flag images (Bashkir, Tatar, Breton).

This is an alternative attempt to resolve build errors related to module resolution for these assets, after issues with absolute paths and the %PUBLIC_URL% placeholder.

The success of this pathing strategy depends on the specific Craco/Webpack configuration for handling such relative URLs from CSS in the src directory pointing to assets in the public directory.