### PR TITLE
Feat: Integrate and adapt provided 'old' CSS for freestyle mode

### DIFF
--- a/src/components/Freestyle/freestyle-shared.css
+++ b/src/components/Freestyle/freestyle-shared.css
@@ -1,3 +1,4 @@
+/* Existing freestyle-shared.css content */
 .freestyle-mode-container {
   display: flex; /* Use flexbox to manage layout */
   flex-direction: column; /* Stack children vertically */
@@ -13,12 +14,12 @@
   padding: var(--spacing-xl, 30px); /* Increased padding, use theme variable */
   border-radius: var(--border-radius-xl, 12px); /* Use XL radius */
   box-shadow: var(--shadow-md, 0 8px 16px rgba(0, 0, 0, 0.15)); /* Enhanced shadow for depth */
-  width: 100%; 
+  width: 100%;
   max-width: 600px; /* Adjusted max width for a more spacious menu */
   margin-bottom: var(--spacing-xl, 30px); /* Increased space, use theme variable */
   display: flex;
   flex-direction: column;
-  align-items: center; 
+  align-items: center;
   gap: var(--spacing-md, 1rem); /* Add gap between items in the menu box */
   animation: fadeInUp 0.5s ease-out 0.1s forwards; /* Stagger animation slightly */
 }
@@ -26,7 +27,7 @@
 .freestyle-mode-header {
   text-align: center;
   color: var(--color-text-headings, #2c3e50); /* Use theme variable */
-  margin-bottom: var(--spacing-lg, 20px); 
+  margin-bottom: var(--spacing-lg, 20px);
   font-size: var(--font-size-h1, 2.4rem); /* Larger font size */
   font-weight: 600; /* Bolder */
 }
@@ -57,60 +58,60 @@
 
 
 .study-mode-button {
-  background-color: var(--color-primary, #007bff); 
+  background-color: var(--color-primary, #007bff);
   color: var(--color-text-on-dark, white);
   padding: var(--spacing-md, 12px) var(--spacing-lg, 30px);
   border-radius: var(--border-radius-lg, 8px);
   text-decoration: none;
   font-weight: bold;
-  font-size: var(--font-size-lg, 1.15rem); 
-  box-shadow: var(--shadow-sm, 0 4px 8px rgba(0,0,0,0.1)); 
+  font-size: var(--font-size-lg, 1.15rem);
+  box-shadow: var(--shadow-sm, 0 4px 8px rgba(0,0,0,0.1));
   cursor: pointer;
   border: none;
-  transition: background-color 0.2s ease-in-out, transform 0.15s ease, box-shadow 0.15s ease; 
+  transition: background-color 0.2s ease-in-out, transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .study-mode-button:hover {
-  background-color: var(--color-primary-dark, #0056b3); 
+  background-color: var(--color-primary-dark, #0056b3);
   transform: translateY(-4px) scale(1.05); /* More lift and scale */
   box-shadow: var(--shadow-lg, 0 8px 15px rgba(0,0,0,0.2)); /* Stronger shadow */
 }
 
 .study-mode-button:active {
-  transform: translateY(0px) scale(1); 
+  transform: translateY(0px) scale(1);
   box-shadow: var(--shadow-sm, 0 2px 4px rgba(0,0,0,0.1));
 }
 
 
 .freestyle-mode-exercise-host {
-  margin-top: var(--spacing-lg, 20px); 
-  padding: var(--spacing-xl, 30px); 
-  border-top: 4px solid var(--color-primary, #007bff); 
+  margin-top: var(--spacing-lg, 20px);
+  padding: var(--spacing-xl, 30px);
+  border-top: 4px solid var(--color-primary, #007bff);
   width: 100%;
-  max-width: 800px; 
-  background-color: var(--color-background, #ffffff); 
+  max-width: 800px;
+  background-color: var(--color-background, #ffffff);
   border-radius: var(--border-radius-xl, 12px); /* Use XL radius */
-  box-shadow: var(--shadow-md, 0 4px 10px rgba(0,0,0,0.08)); 
+  box-shadow: var(--shadow-md, 0 4px 10px rgba(0,0,0,0.08));
   animation: scaleIn 0.4s ease-out 0.3s forwards; /* Stagger animation */
 }
 
 .freestyle-mode-message {
   text-align: center;
   font-style: italic;
-  color: var(--color-text-secondary, #5a6570); 
-  padding: var(--spacing-xl, 30px); 
-  font-size: var(--font-size-lg, 1.1rem); 
+  color: var(--color-text-secondary, #5a6570);
+  padding: var(--spacing-xl, 30px);
+  font-size: var(--font-size-lg, 1.1rem);
 }
 
 /* Global elements styles */
 .freestyle-mode-root {
-  min-height: 100vh; 
-  width: 100%; 
+  min-height: 100vh;
+  width: 100%;
   position: relative;
   display: flex;
-  flex-direction: column; 
-  align-items: center; 
-  padding: var(--spacing-md, 20px); 
+  flex-direction: column;
+  align-items: center;
+  padding: var(--spacing-md, 20px);
   box-sizing: border-box;
 }
 
@@ -189,25 +190,21 @@
 /* Body styles might be better in a global CSS like index.css if not already present,
    but including here if this CSS is meant to be self-contained for the freestyle page. */
 body.freestyle-page-active { /* Scoping body style to when freestyle page is active, if possible/needed */
-  font-family: sans-serif;
+  font-family: sans-serif; /* This will be overridden by global body styles */
   margin: 0; /* Usually handled by reset/normalize */
   padding: 20px; /* This might conflict with .freestyle-mode-container padding */
-  background-color: #f4f4f4; /* Default page background */
-  color: #333;
+  background-color: #f4f4f4; /* Default page background, likely overridden by language flags */
+  color: #333; /* Overridden by global body styles */
 }
 
 .island-placeholder {
   padding: 15px;
   margin-bottom: 15px;
-  border: 1px dashed #ccc;
+  border: 1px dashed #ccc; /* Consider var(--color-border) */
   border-radius: 4px; /* Consider var(--border-radius-md) */
-  background-color: #f9f9f9; /* Consider var(--color-surface-raised) */
+  background-color: #f9f9f9; /* Consider var(--color-surface) */
 }
 
-/* Specific island container styling - can be merged with .selector-container if appropriate
-   or if they need distinct spacing beyond what .island-placeholder provides.
-   The existing .selector-container already provides margin-bottom.
-*/
 #language-selector-island-container.island-placeholder {
   /* margin-bottom: 20px; -- Covered by .selector-container or .island-placeholder */
 }
@@ -216,36 +213,17 @@ body.freestyle-page-active { /* Scoping body style to when freestyle page is act
   /* margin-bottom: 20px; -- Covered by .selector-container or .island-placeholder */
 }
 
-/* Styling for the exercise host container.
-   It already has class .freestyle-mode-exercise-host (from existing CSS)
-   and .island-placeholder (new).
-   The inline style was: padding-top: 20px; border-top: 1px solid #eee;
-   The existing .freestyle-mode-exercise-host has:
-   border-top: 4px solid var(--color-primary, #007bff);
-   padding: var(--spacing-xl, 30px);
-   So, the specific inline styles might be redundant or can be merged if needed.
-   Let's assume the existing .freestyle-mode-exercise-host styles are preferred.
-*/
 #exercise-host-container.island-placeholder {
   /* padding-top: 20px; */ /* Covered by .freestyle-mode-exercise-host padding */
   /* border-top: 1px solid #eee; */ /* Overridden by .freestyle-mode-exercise-host border-top */
 }
-
-/* General label style, if not covered by more specific component styles */
-/* This might be too broad. Prefer styling labels within their components or specific containers.
-label {
-  display: block;
-  margin-bottom: 5px;
-  font-weight: bold;
-}
-*/
 
 @media (max-width: 480px) {
   .freestyle-mode-container {
     padding: var(--spacing-md, 15px);
   }
   .main-menu-box {
-    max-width: 95%; 
+    max-width: 95%;
     padding: var(--spacing-md, 15px);
   }
   .freestyle-mode-header {
@@ -263,4 +241,785 @@ label {
     height: 50px;
     font-size: 1.5rem;
   }
+}
+
+/* ==========================================================================
+   Styles from User Provided "Old" CSS - Integrated and Adapted
+   ========================================================================== */
+
+/* Typography from old CSS - applied within freestyle context if needed */
+/* Generic h1-h6, p, a are handled by src/index.css global styles */
+/* Old h1 style - specific for freestyle header if different from .freestyle-mode-header */
+/* .freestyle-mode-header already covers this. If old h1 style is preferred:
+.freestyle-mode-header {
+    font-size: 2rem;
+    text-align: center;
+    color: var(--color-text-on-dark);
+    margin-bottom: var(--spacing-lg);
+    letter-spacing: 1px;
+    text-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+*/
+/* Old label style - .unified-label from src/index.css is preferred for consistency */
+/* If specific label styling for freestyle is needed:
+.freestyle-label {
+    display: block; margin-bottom: var(--spacing-sm); font-weight: bold;
+    color: var(--color-text-primary);
+    text-align: left;
+    font-size: var(--font-size-base);
+    letter-spacing: 0.25px;
+    transition: color 0.2s ease-in-out;
+}
+*/
+/* Styles for labels within the old .container (now freestyle-main-content-wrapper) */
+.freestyle-main-content-wrapper label { /* Assuming .freestyle-main-content-wrapper replaces old .container */
+    color: var(--color-text-on-dark); /* Original: var(--text-color-light) */
+    text-align: center;
+}
+.freestyle-main-content-wrapper label:hover {
+    color: #ffe082; /* Keep specific hover color if desired */
+}
+
+
+/* Layout & Main Containers from old CSS */
+/* This .container from old CSS seems like the main content box for freestyle.
+   Let's map it to a new class or adapt .main-menu-box if it serves this purpose.
+   If .main-menu-box is for the initial menu, and this is for the main content area: */
+.freestyle-main-content-wrapper { /* Renamed from old .container */
+    background: linear-gradient(135deg, hsla(178, 90%, 38%, 0.97) 0%, hsla(178, 90%, 48%, 0.90) 100%);
+    padding: var(--spacing-lg); /* old: 20px -> var(--spacing-lg) or var(--spacing-xl) */
+    border-radius: var(--border-radius-xl); /* old: 12px */
+    box-shadow: 0 6px 20px rgba(31, 38, 135, 0.15);
+    display: flex; flex-direction: column; align-items: center; justify-content: flex-start;
+    animation: fadeInUp 0.7s cubic-bezier(.23,1.01,.32,1) 0.1s both; /* fadeInUp is in src/index.css */
+    width: 95%; max-width: 700px;
+    min-width: 300px;
+    margin: var(--spacing-lg) auto; /* old: 20px auto */
+    box-sizing: border-box;
+}
+
+/* .menu-section from old CSS - for sections within the main wrapper */
+/* This might be too generic. React components should define their own layout.
+   If needed, a more specific class like .freestyle-menu-section can be used by components.
+.freestyle-menu-section {
+    margin-bottom: var(--spacing-lg);
+    display: flex; flex-direction: column;
+    align-items: center;
+    position: relative;
+    width:100%;
+}
+*/
+
+/* .practice-types from old CSS - used by PracticeCategoryNav.js */
+/* PracticeCategoryNav.js has .practice-category-nav-container and .practice-category-buttons */
+/* We can adapt .practice-types to style .practice-category-buttons */
+.practice-category-buttons { /* Adapting old .practice-types */
+    display: flex; flex-wrap: wrap; gap: var(--spacing-sm); /* old gap: 8px */
+    justify-content: center;
+    margin-bottom: var(--spacing-md); /* old: 15px */
+}
+
+/* .practice-options and specific sub-options from old CSS - used by SubPracticeMenu.js */
+/* SubPracticeMenu.js has .sub-practice-menu-container and reuses .practice-category-buttons */
+/* These styles seem to target the container for sub-practice buttons */
+.sub-practice-menu-container .practice-category-buttons { /* Targets the button group within sub-menu */
+    /* Styles from old .vocabulary-options, .grammar-options, etc. */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm); /* old: 8px */
+    width: 100%;
+    padding: var(--spacing-xs) 0; /* old: 5px 0 */
+    margin-top: var(--spacing-sm); /* old: 10px */
+}
+/* Old .practice-options: display: none; by default. Current components handle visibility. */
+
+
+.result-area { /* From old CSS, for displaying exercise results/feedback */
+    background-color: var(--color-surface); /* old: var(--light-grey) */
+    color: var(--color-text-primary); /* old: var(--text-color-dark) */
+    border-radius: var(--border-radius-lg); /* old: 10px */
+    padding: var(--spacing-xl); /* old: 25px */
+    margin: var(--spacing-xl) auto; /* old: 25px auto */
+    box-shadow: var(--shadow-md); /* old: 0 6px 18px rgba(0, 0, 0, 0.07) */
+    text-align: center;
+    font-size: var(--font-size-lg); /* old: 1.05rem, var(--font-size-lg) is 1.25rem or 1.15rem */
+    line-height: 1.6;
+    min-height: 120px;
+    animation: popIn 0.5s cubic-bezier(.23,1.01,.32,1) 0.1s both; /* popIn needs to be defined or available */
+    width: 100%;
+    max-width: 700px;
+    border: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+.result-area:not(:empty) {
+    justify-content: flex-start;
+}
+
+/* Buttons from old CSS - to be used for specific freestyle buttons */
+/* Avoid redefining generic .btn. Instead, create .freestyle-btn or apply to specific components */
+
+/* Styles for buttons within .practice-types (now .practice-category-buttons) */
+/* PracticeCategoryNav.js renders buttons with .practice-category-btn */
+.practice-category-btn { /* Merging styles from old .practice-types button */
+    color: var(--color-text-on-dark);
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
+    padding: 0.7em 1.3em; /* from old */
+    font-size: 0.95rem; /* from old */
+    /* Other .btn properties like font-weight, border-radius, transition are in global .btn */
+}
+.practice-category-btn:hover {
+    background-color: var(--color-primary-dark);
+    border-color: var(--color-primary-dark);
+}
+
+/* Styles for buttons within .practice-options (now .sub-practice-menu-container .practice-category-buttons button) */
+/* SubPracticeMenu.js renders buttons with .practice-category-btn.sub-practice-btn */
+.sub-practice-btn { /* Adapting old .practice-options button */
+    font-size: 0.9rem; padding: 0.7em 1.3em;
+    font-weight: 600; border-radius: var(--border-radius-lg); /* old: 8px */
+    margin: var(--spacing-xs); /* old: 5px */
+    background: linear-gradient(90deg, #ffe082 0%, #1de9b6 100%);
+    color: #006666; border: none;
+    box-shadow: var(--shadow-sm); /* old: 0 2px 12px rgba(0,0,0,0.08) */
+    transition: transform 0.18s, box-shadow 0.18s, background 0.18s;
+}
+.sub-practice-btn:hover {
+    transform: scale(1.08) rotate(-2deg);
+    background: linear-gradient(90deg, #1de9b6 0%, #ffe082 100%);
+    box-shadow: var(--shadow-md); /* old: 0 4px 18px rgba(0,0,0,0.13) */
+}
+.sub-practice-btn.active, /* Assuming .active is used by React component for active state */
+.sub-practice-btn.active-option-btn { /* Keep old class if used */
+    background: linear-gradient(90deg, #ffb74d 0%, #00bdbd 100%);
+    color: var(--color-text-on-dark);
+    box-shadow: 0 2px 16px #ffe08299;
+    transform: scale(1.12);
+}
+/* .option-btn from old CSS - seems like a base for practice-options buttons */
+/* Covered by .sub-practice-btn styling */
+
+
+/* Forms & Inputs from old CSS */
+/* Apply to inputs within freestyle context, perhaps .freestyle-main-content-wrapper */
+.freestyle-main-content-wrapper input[type="text"],
+.freestyle-main-content-wrapper textarea,
+.freestyle-main-content-wrapper select {
+    border-radius: var(--border-radius-md); /* old: 0.3rem */
+    padding: 0.6em 1em;
+    font-size: var(--font-size-base); /* old: var(--font-size-normal) */
+    margin-bottom: var(--spacing-sm); /* old: var(--spacing-unit, 10px) */
+    border: 1px solid var(--color-border);
+    background-color: var(--color-surface); /* old: var(--light-grey) */
+    color: var(--color-text-primary); /* old: var(--text-color-dark) */
+    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    width: auto;
+    min-width: 200px;
+    text-align: center;
+}
+.freestyle-main-content-wrapper input[type="text"]:focus,
+.freestyle-main-content-wrapper textarea:focus,
+.freestyle-main-content-wrapper select:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+    background-color: var(--color-background); /* old: #fff */
+}
+
+.exercise-input { /* Utility class from old CSS */
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 300px;
+    width: 90%;
+    /* Inherits specific input styling from above if wrapped in .freestyle-main-content-wrapper */
+}
+textarea.exercise-input {
+    min-height: 80px;
+    resize: vertical;
+}
+
+
+/* Exercise Common Styles from old CSS */
+/* This large group targets various exercise containers.
+   The current .freestyle-mode-exercise-host is a single host.
+   These styles should apply to components *within* .freestyle-mode-exercise-host */
+.exercise-container, /* Generic wrapper for specific exercises if used */
+.word-display-container,
+.opposites-exercise,
+.match-exercise,
+.build-word-exercise,
+.image-exercise,
+.match-image-word-exercise,
+.listening-exercise,
+.match-sound-exercise,
+.gender-exercise,
+.verb-exercise,
+.fill-gap-exercise,
+.word-order-exercise,
+.reading-exercise-container,
+.speaking-exercise-container,
+.writing-exercise-container {
+    background-color: var(--color-background); /* old: #fff */
+    border-radius: var(--border-radius-lg); /* old: 10px */
+    padding: var(--spacing-lg); /* old: var(--spacing-unit, 10px) * 2 -> 20px */
+    box-shadow: var(--shadow-md); /* old: 0 4px 12px rgba(0,0,0,0.1) */
+    max-width: 650px;
+    margin: var(--spacing-lg) auto; /* old: calc(var(--spacing-unit, 10px) * 2) auto */
+    text-align: center;
+}
+
+.exercise-prompt,
+.exercise-container h3,
+.gender-prompt,
+.verb-prompt,
+#speaking-question-text,
+#writing-question-text { /* #id selectors might be too specific if components don't use them */
+    font-size: var(--font-size-lg);
+    margin-bottom: var(--spacing-md); /* old: calc(var(--spacing-unit, 10px) * 1.5) */
+    color: var(--color-text-primary); /* old: var(--text-color-dark) */
+    font-weight: 500;
+    text-align: center;
+    line-height: 1.4;
+}
+#speaking-question-text,
+#writing-question-text { /* These specific IDs from old CSS */
+    text-align: left;
+    background-color: var(--color-surface); /* old: var(--light-grey) */
+    border-left: 4px solid var(--color-primary);
+    padding: var(--spacing-sm); /* old: var(--spacing-unit, 10px) */
+    border-radius: var(--border-radius-sm); /* old: 4px */
+}
+
+.exercise-feedback {
+    margin: var(--spacing-sm) 0; /* old: var(--spacing-unit, 10px) 0 */
+    padding: var(--spacing-sm);
+    min-height: calc(var(--font-size-base) * 2.5); /* old: calc(var(--font-size-normal, 1rem) * 2.5) */
+    border-radius: var(--border-radius-sm); /* old: 4px */
+    font-size: var(--font-size-sm); /* old: var(--font-size-small, 0.85rem) */
+    text-align: center;
+    border: 1px solid transparent;
+    line-height: 1.5;
+}
+.exercise-feedback.correct,
+.exercise-feedback span.correct,
+.exercise-feedback span[style*="#27ae60"] {
+    color: var(--color-success-text) !important;
+    background-color: var(--color-success-bg) !important;
+    border-color: var(--color-success-border) !important;
+    display: block;
+}
+.exercise-feedback.incorrect,
+.exercise-feedback span.incorrect,
+.exercise-feedback span[style*="#e74c3c"] {
+    color: var(--color-danger-text) !important;
+    background-color: var(--color-danger-bg) !important;
+    border-color: var(--color-danger-border) !important;
+    display: block;
+}
+
+.exercise-actions,
+.word-actions,
+.word-exercise-options,
+.build-actions,
+.navigation-buttons, /* This is also used by ExerciseControls.js */
+.listening-exercise .exercise-actions,
+.image-exercise .exercise-actions,
+.match-sound-exercise .exercise-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-sm); /* old: var(--spacing-unit, 10px) */
+    margin-top: var(--spacing-lg); /* old: calc(var(--spacing-unit, 10px) * 2) */
+    margin-bottom: var(--spacing-sm);
+}
+.navigation-buttons { /* Specific override for navigation buttons if used */
+    justify-content: space-between;
+}
+
+/* Specific Exercise Type Styles from old CSS (adapted) */
+.word-display-container { padding: var(--spacing-sm) var(--spacing-md); }
+.word-display {
+    font-size: 1.8rem; font-weight: bold; margin: var(--spacing-sm) 0;
+    padding:var(--spacing-sm); background-color: var(--color-surface);
+    border-radius: var(--border-radius-sm); color: var(--color-primary);
+}
+.opposites-exercise { padding: var(--spacing-md); }
+.word-pair {
+    display: flex; justify-content: center; align-items: center;
+    gap: var(--spacing-sm); margin: var(--spacing-md) 0;
+}
+.word-box {
+    padding: var(--spacing-sm) var(--spacing-md); background: var(--color-surface-medium);
+    color: var(--color-text-primary); border-radius: var(--border-radius-md); font-size: 1.1rem;
+}
+.opposite-arrow { font-size: 1.5rem; color: var(--color-text-secondary); } /* old: var(--dark-grey) */
+.opposite-answer { background: var(--color-background); border: 2px dashed var(--color-primary); } /* old: #fff */
+
+.build-word-exercise { max-width: 500px; }
+.vocabulary-image {
+    max-width: 200px; max-height: 150px; display: block; margin: var(--spacing-md) auto;
+    border: 1px solid var(--color-surface-medium); border-radius: var(--border-radius-sm);
+    transition: transform 0.2s ease-in-out;
+}
+.vocabulary-image:hover { transform: scale(1.05); }
+
+.match-container {
+    display: flex; justify-content: space-around; gap: var(--spacing-md); margin: var(--spacing-md) 0;
+}
+.match-col { flex: 1; display: flex; flex-direction: column; gap: var(--spacing-sm); }
+.match-item {
+    padding: var(--spacing-sm); margin: 0;
+    border: 1px solid var(--color-surface-medium); border-radius: var(--border-radius-sm); cursor: pointer;
+    background-color: var(--color-background);
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, transform 0.15s ease-in-out;
+}
+.match-item:hover { border-color: var(--color-primary); background-color: var(--color-surface); }
+.match-item.selected {
+    border-color: var(--color-primary); background-color: var(--color-primary);
+    color: var(--color-text-on-dark); transform: scale(1.05);
+}
+.match-item.matched {
+    border-color: var(--color-success-border); background-color: var(--color-success-bg);
+    color: var(--color-success-text); cursor: default;
+}
+.match-item.disabled { pointer-events: none; opacity: 0.7; }
+.match-item.incorrect-flash { animation: incorrectFlash 0.5s; } /* incorrectFlash to be defined */
+
+/* .gender-exercise .gender-prompt already covered by .exercise-prompt */
+
+/* Word/Letter Pools and Slots from old CSS */
+.word-pool, .letter-pool {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-sm); margin: var(--spacing-md) 0; padding: var(--spacing-sm);
+    background: var(--color-surface); border-radius: var(--border-radius-md);
+}
+.word-tile, .letter-tile {
+    padding: var(--spacing-sm) var(--spacing-sm); background: var(--color-primary);
+    color: var(--color-text-on-dark);
+    border-radius: var(--border-radius-sm); cursor: grab; user-select: none;
+    min-width: 35px; min-height: 35px;
+    display: flex; justify-content: center; align-items: center;
+    font-size: 0.9rem; margin: calc(var(--spacing-xs)/2); border: none;
+    transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+.word-tile:hover, .letter-tile:hover {
+    transform: translateY(-2px); box-shadow: var(--shadow-sm);
+    background-color: var(--color-primary-dark);
+}
+.letter-tile.dragging { opacity: 0.6; transform: scale(1.1); }
+.word-slots, .letter-slots {
+    display:flex; justify-content:center; gap: var(--spacing-xs); margin: var(--spacing-md) 0;
+}
+.word-slot, .letter-slot {
+    min-width: 35px; min-height: 35px; background: var(--color-surface-medium);
+    border: 1px dashed var(--color-text-secondary); border-radius: var(--border-radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.letter-slot.hovered { background: var(--color-surface); border-style: solid; }
+
+/* Randomizer Button from old CSS - existing #floating-help-btn might be similar or adaptable */
+/* This .randomizer-button has many !important flags. If this is a distinct button, add it.
+   If it's meant to style an existing button, try to do so without !important.
+   For now, adding it as is, assuming it's a new distinct element. */
+.randomizer-button {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  padding: 0 !important;
+  color: var(--color-text-primary) !important; /* old: var(--text-color-dark) */
+  line-height: 1 !important;
+  text-decoration: none !important;
+  margin-left: var(--spacing-sm) !important; /* old: 10px */
+  float: right !important;
+  font-size: 1.5rem !important;
+  background: linear-gradient(90deg,#ffe082,#1de9b6) !important;
+  border: none !important;
+  border-radius: 50% !important;
+  width: 44px !important;
+  height: 44px !important;
+  box-shadow: 0 2px 8px #ccc !important; /* Consider var(--shadow-sm) */
+  cursor: pointer !important;
+  transition: transform 0.2s !important;
+}
+.randomizer-button:hover {
+  transform: scale(1.15) !important;
+}
+
+/* TF and Choose4 specific styles from old CSS */
+.tf-container { gap: var(--spacing-sm); margin: var(--spacing-md) 0 var(--spacing-sm) 0; }
+.tf-statement { font-size: 1.1em; margin-bottom: var(--spacing-sm); }
+.tf-btns { gap: var(--spacing-sm); margin-bottom: var(--spacing-sm); }
+.choose4-container { gap: var(--spacing-sm); margin: var(--spacing-md) 0 var(--spacing-sm) 0; }
+.choose4-question { font-size: 1.1rem; color: var(--color-primary); margin-bottom: var(--spacing-xs); }
+.choose4-options { gap: var(--spacing-sm); }
+#reset-progress-btn {
+    padding: 0.6em 1.2em; font-size: 0.9rem; font-weight: bold;
+    color: var(--color-text-primary); background-color: var(--color-surface-medium);
+    border: 1px solid var(--color-text-secondary); border-radius: var(--border-radius-md); cursor: pointer;
+    margin: var(--spacing-md) auto 0 auto; display: block; /* old: 18px */
+}
+#reset-progress-btn:hover {
+    background-color: #d3d9df; border-color: #9fa6ac; color: #222;
+}
+
+/* Styles for Build Word Exercise - Click to move from old CSS */
+.letter-pool.clickable .letter-tile {
+    cursor: pointer;
+}
+.letter-slot.clickable {
+    cursor: pointer;
+}
+
+/* Speaking and Writing Exercises from old CSS */
+.speaking-exercise-container h3,
+.writing-exercise-container h3 {
+    color: var(--color-primary);
+}
+#speaking-record-btn { /* Specific ID from old CSS */
+    font-size: 2.5em !important;
+    padding: var(--spacing-sm) var(--spacing-md) !important;
+    margin-bottom: var(--spacing-md) !important;
+    line-height: 1 !important;
+}
+#speaking-record-btn.recording {
+    background-color: var(--color-danger-bg); /* old: var(--error-bg) */
+    color: var(--color-danger-text); /* old: var(--error-text) */
+    animation: pulseAnimation 1.5s infinite; /* pulseAnimation needs to be defined */
+}
+#speaking-transcript { /* Specific ID from old CSS */
+    margin-top: var(--spacing-md);
+    padding: var(--spacing-sm);
+    min-height: 30px;
+    font-style: italic;
+    color: #555;
+    background-color: var(--color-surface); /* old: #f9f9f9 */
+    border: 1px dashed var(--color-border);
+    border-radius: var(--border-radius-sm);
+    line-height: 1.5;
+}
+#writing-answer-area { /* Specific ID from old CSS */
+    width: 100%;
+    max-width: 100%;
+    padding: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-sm);
+    font-size: var(--font-size-base);
+    line-height: 1.5;
+    min-height: 100px;
+    resize: vertical;
+}
+#writing-answer-area:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
+}
+#submit-writing-answer-btn { /* Specific ID from old CSS */
+    padding: var(--spacing-sm) var(--spacing-md);
+    margin-bottom: var(--spacing-sm);
+    min-width: 150px;
+}
+
+/* UI Components from old CSS (Popups, Modals, Stats, Toasts) */
+/* #cosy-gamestats, .cosy-toast, #floating-help-btn are already in existing CSS.
+   Compare and merge if old styles are preferred or add new aspects.
+   For now, assuming existing are kept, and adding .floating-popup as it seems new. */
+
+.floating-popup {  /* From old CSS */
+  position: fixed; left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  background-color: var(--color-background); /* old: #fff */
+  padding: var(--spacing-lg); /* old: 20px */
+  border-radius: var(--border-radius-lg);  /* old: 8px */
+  box-shadow: var(--shadow-lg);  /* old: 0 5px 15px rgba(0,0,0,0.2) */
+  z-index: 1002; width: 90%; max-width: 400px;
+  transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+.floating-popup .popup-header {
+    font-size: 1.1rem; font-weight: bold; margin-bottom: var(--spacing-sm);
+    color: var(--color-primary);
+}
+.floating-popup .popup-content {
+    margin-bottom: var(--spacing-md); font-size: 0.9rem; line-height: 1.5;
+}
+.floating-popup .popup-actions { text-align: right; }
+.floating-popup .close-btn {
+    background: none; border: none; font-size: 1.2rem;
+    color: var(--color-text-secondary); cursor: pointer; padding: var(--spacing-xs);
+    transition: color 0.2s ease-in-out;
+}
+.floating-popup .close-btn:hover { color: var(--color-primary); }
+/* Ensure these are visible if display:flex is set by JS */
+#floating-tip-popup[style*="display: flex"] { display: flex !important; }
+#translation-popup[style*="display: flex"] { display: flex !important; }
+
+/* Animations & Keyframes from old CSS */
+/* fadeInUp is already in src/index.css. popIn, gamestatsLevelUp, sparkle, incorrectFlash, bounceIn are new. */
+@keyframes popIn { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
+@keyframes gamestatsLevelUp {
+    0% { transform: scale(1); box-shadow: var(--shadow-sm); }
+    50% { transform: scale(1.15) rotate(-3deg); box-shadow: 0 4px 10px rgba(0,123,255,0.5); }
+    100% { transform: scale(1); box-shadow: var(--shadow-sm); }
+}
+.result-area span[style*='#27ae60']::after {  content: ' ✨'; animation: sparkle 0.7s linear; }
+@keyframes sparkle {
+    0% { opacity: 0; transform: scale(0.7) rotate(-10deg); }
+    60% { opacity: 1; transform: scale(1.2) rotate(10deg); }
+    100% { opacity: 0; transform: scale(0.7) rotate(-10deg); }
+}
+@keyframes incorrectFlash {
+    0%, 100% { background-color: var(--color-danger-bg); } /* old: var(--error-bg) */
+    50% { background-color: var(--color-background); } /* old: #fff */
+}
+@keyframes bounceIn {
+    0% { transform: scale(0.8); opacity: 0.2; }
+    60% { transform: scale(1.15); opacity: 1; }
+    100% { transform: scale(1); opacity: 1; }
+}
+@keyframes pulseAnimation { /* From old CSS for speaking button */
+    0% { box-shadow: 0 0 0 0 rgba(211, 47, 47, 0.7); }
+    70% { box-shadow: 0 0 0 10px rgba(211, 47, 47, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(211, 47, 47, 0); }
+}
+
+
+/* Media Queries from old CSS - To be merged with existing media queries if necessary, or added if distinct */
+/* Existing media queries in freestyle-shared.css already cover 768px and 480px.
+   These old ones might have different specifics. Appending for now. */
+@media (max-width: 900px) {
+  .freestyle-main-content-wrapper { /* old .container */
+    width: 95%; padding: var(--spacing-md);
+  }
+  /* Old h1 already covered by .freestyle-mode-header media query */
+}
+@media (max-width: 600px) {
+  /* body padding 0 - handled by global reset */
+  .freestyle-main-content-wrapper { /* old .container */
+    width: 100%; max-width: 100vw; margin: 0; border-radius: 0;
+    padding: var(--spacing-md) var(--spacing-sm);
+  }
+  /* old h1, label, result-area, practice-types, practice-options, word-display etc.
+     Need to check if these specific adjustments are still relevant or covered by existing responsive styles.
+     For instance, .freestyle-mode-header already has @media rules.
+  */
+  .freestyle-main-content-wrapper label { font-size: 0.9rem; } /* Example of specific adaptation */
+  .result-area { font-size: 0.9rem; padding: var(--spacing-md) var(--spacing-sm); }
+  .practice-category-buttons { flex-direction: column; gap: var(--spacing-sm); } /* old .practice-types */
+  .sub-practice-menu-container .practice-category-buttons { gap: var(--spacing-sm); margin: var(--spacing-md) 0; } /* old .practice-options */
+  .sub-practice-btn { font-size: 0.85rem; padding: 0.6em 1em; }  /* old .practice-options button */
+  .word-display { font-size: 1.5rem; }
+  .word-box { font-size: 1rem; padding: var(--spacing-sm) var(--spacing-sm); }
+  .opposite-arrow { font-size: 1.2rem; }
+  .letter-tile { font-size: 1rem; padding: calc(var(--spacing-xs)/2) var(--spacing-sm); min-width: 30px; min-height: 30px; }
+  .letter-slot { min-width: 30px; min-height: 30px; }
+  .match-item { padding: var(--spacing-sm); font-size: 0.9rem; }
+  /* #floating-help-btn already has media queries */
+  .floating-popup { width: 95%; padding: var(--spacing-md);}
+  .choose4-options { flex-direction: column; gap: var(--spacing-sm); } /* From old CSS */
+  .choose4-container .choose4-btn { min-width: 90vw; font-size: 1em; } /* From old CSS */
+}
+
+/* Unified grid and item sizing for match-image-word-exercise from old CSS */
+.match-image-word-exercise .match-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-md); /* old: 18px */
+  justify-items: center;
+  align-items: center;
+  margin: var(--spacing-lg) 0 var(--spacing-xl) 0; /* old: 20px 0 24px 0 */
+}
+
+.match-image-word-exercise .match-item,
+.match-image-word-exercise .image-item, /* Added from old CSS for consistency */
+.match-image-word-exercise .word-item {  /* Added from old CSS for consistency */
+  width: 120px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-surface-medium); /* old: var(--medium-grey) */
+  border-radius: var(--border-radius-lg); /* old: 8px */
+  background: var(--color-background); /* old: #fff */
+  box-shadow: var(--shadow-sm); /* old: 0 2px 8px rgba(0,0,0,0.06) */
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.18s, border-color 0.18s, box-shadow 0.18s, transform 0.15s;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+.match-image-word-exercise .match-item img,
+.match-image-word-exercise .image-item img {
+  max-width: 80px;
+  max-height: 80px;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+.match-image-word-exercise .word-item { /* Added from old CSS */
+  font-weight: 600;
+  color: var(--color-primary);
+  text-align: center;
+  word-break: break-word;
+  padding: 0 var(--spacing-sm);
+}
+.match-image-word-exercise .match-item.selected {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-text-on-dark);
+  transform: scale(1.05);
+}
+.match-image-word-exercise .match-item.matched {
+  border-color: var(--color-success-border);
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
+  cursor: default;
+}
+.match-image-word-exercise .match-item.disabled {
+  pointer-events: none;
+  opacity: 0.7;
+}
+.match-image-word-exercise .match-item.incorrect-flash {
+  animation: incorrectFlash 0.5s;
+}
+
+@media (max-width: 700px) { /* From old CSS for match-image-word */
+  .match-image-word-exercise .match-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-sm); /* old: 12px */
+  }
+  .match-image-word-exercise .match-item,
+  .match-image-word-exercise .image-item,
+  .match-image-word-exercise .word-item {
+    width: 90px;
+    height: 90px;
+    font-size: 1rem;
+  }
+  .match-image-word-exercise .match-item img,
+  .match-image-word-exercise .image-item img {
+    max-width: 60px;
+    max-height: 60px;
+  }
+}
+
+/* Added styles for gender exercises from old CSS (adapted) */
+/* Base button style - .btn-primary, .btn-secondary, .btn-emoji are defined globally or above.
+   .article-option-btn is new. */
+
+/* Specific for article option buttons in 'Select the Article' exercise */
+.article-options-container { /* From old CSS */
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: var(--spacing-md) 0;
+}
+.article-option-btn { /* From old CSS, adapted */
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius-lg);
+    border: 1px solid transparent;
+    font-size: var(--font-size-base);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
+    margin: var(--spacing-xs);
+    box-shadow: var(--shadow-sm);
+    background-color: #e3f2fd;
+    color: #0d47a1;
+    border-color: #90caf9;
+    min-width: 80px;
+}
+.article-option-btn:hover {
+    background-color: #bbdefb;
+    border-color: #64b5f6;
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+}
+.article-option-btn.correct-selection {
+    background-color: var(--color-success-bg) !important;
+    color: var(--color-success-text) !important;
+    border-color: var(--color-success-border) !important;
+    transform: scale(1.05);
+}
+.article-option-btn.incorrect-selection {
+    background-color: var(--color-danger-bg) !important;
+    color: var(--color-danger-text) !important;
+    border-color: var(--color-danger-border) !important;
+    opacity: 0.7;
+}
+.article-option-btn:disabled:not(.correct-selection):not(.incorrect-selection) {
+    background-color: var(--color-surface); /* old: #f5f5f5 */
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+/* Feedback Message Styling - Refined from old CSS, ensuring consistency with .exercise-feedback */
+/* .exercise-feedback .correct and .incorrect are already styled above.
+   The old CSS had slightly different styling for these classes when nested.
+   The current .exercise-feedback.correct/incorrect should suffice. */
+
+/* Exercise Container Styling from old CSS - .exercise-container group covers this */
+/* The old CSS had a more specific rule for these, potentially overriding .exercise-container.
+   If these need distinct styling from generic .exercise-container: */
+.gender-exercise, .match-exercise, .select-article-exercise,
+.verb-exercise, .fill-gap-exercise, .word-order-exercise {
+    /* padding: var(--spacing-lg); -- from .exercise-container */
+    /* margin: var(--spacing-lg) auto; -- from .exercise-container */
+    border: 1px solid var(--color-border); /* old: #e0e0e0 */
+    /* border-radius: var(--border-radius-lg); -- from .exercise-container */
+    /* background-color: var(--color-background); -- from .exercise-container */
+    box-shadow: var(--shadow-sm); /* old: 0 3px 10px rgba(0,0,0,0.05), more subtle than .exercise-container's --shadow-md */
+    max-width: 600px; /* More specific than .exercise-container's 650px if desired */
+}
+
+/* Prompts within exercises from old CSS - .exercise-prompt group covers this */
+/* More specific prompt styling from old CSS */
+.gender-prompt, .verb-prompt,
+.sentence-with-gap, /* New class from old CSS */
+.word-order-exercise h3, .fill-gap-exercise h3, .match-exercise h3 { /* Targeting specific h3s */
+    font-size: 1.2em;
+    color: var(--color-text-primary); /* old: #333 */
+    /* margin-bottom: var(--spacing-md); -- from .exercise-prompt */
+    /* text-align: center; -- from .exercise-prompt */
+}
+.select-article-exercise .exercise-prompt strong { /* From old CSS */
+    font-weight: 600;
+    color: var(--color-primary); /* old: #1976d2 */
+}
+
+/* Input field styling from old CSS - .exercise-input already adapted */
+
+/* Matching Game Layout Styling from old CSS - .match-container, .match-col, .match-item adapted */
+/* The old CSS had some specific overrides for .match-item here vs the general one. */
+.match-exercise .match-item { /* Making it specific to .match-exercise */
+    margin: var(--spacing-sm) 0;
+    box-shadow: var(--shadow-sm);
+}
+.match-exercise .match-item:hover {
+    background-color: #eef8ff;
+    border-color: #aaccf0;
+    box-shadow: var(--shadow-md);
+    transform: scale(1.03);
+}
+.match-exercise .match-item.selected {
+    background-color: #cfe8fc;
+    border-color: #79b7f7;
+    font-weight: bold;
+    box-shadow: 0 0 5px rgba(0,123,255,0.5);
+}
+.match-exercise .match-item.matched {
+    opacity: 0.7;
+    transform: scale(0.95);
+}
+.match-exercise .match-col h4 {
+    text-align: center;
+    color: var(--color-text-secondary); /* old: #555 */
+    margin-bottom: var(--spacing-sm);
 }


### PR DESCRIPTION
- I merged styles from the CSS block you provided into src/components/Freestyle/freestyle-shared.css.
- I adapted CSS variables from the old styles to use the existing theme variables from src/index.css (e.g., --primary-color to --color-primary).
- I prioritized integration of freestyle-specific layout, component, and exercise styles (e.g., .freestyle-main-content-wrapper, .practice-options button styling, various .exercise-* classes, .result-area, .floating-popup).
- I omitted or was cautious with old global styles (html, body, generic tags), generic .btn definitions, and redundant flag/CSS-translation rules to maintain global consistency and avoid broad conflicts with the existing theme.
- I added new keyframe animations from the provided CSS.
- I appended old media queries, which may need further review for overlap.

This aims to bring in desired visual elements and styles from a previous freestyle implementation into the current structure.