### PR TITLE
Fix: Ensure language flag backgrounds apply by removing JS class check

### DIFF
--- a/src/components/Freestyle/LanguageSelectorFreestyle.js
+++ b/src/components/Freestyle/LanguageSelectorFreestyle.js
@@ -54,22 +54,17 @@ const LanguageSelectorFreestyle = ({ onLanguageChange }) => { // Accept onLangua
 
         if (currentLangKey && currentLangKey !== "null") { // Ensure currentLangKey is not the string "null"
             const langClassName = `${currentLangKey}-bg`; // Uses new standardized key
-            // A more robust check for class existence might be needed if dynamic loading of CSS is complex.
-            // This check might be intensive, consider if truly necessary.
-            const classExists = Array.from(document.styleSheets).some(sheet => {
-                try {
-                  return Array.from(sheet.cssRules || []).some(rule => rule.selectorText === `.${langClassName}`);
-                } catch (e) { return false; }
-            });
 
-            if (classExists) {
-                body.classList.add(langClassName);
-                body.classList.add('lang-bg'); // General class for styling shared background properties
-            } else {
-                body.classList.add('lang-bg-fallback');
-            }
+            // Remove the classExists check and unconditionally add classes
+            body.classList.add(langClassName);
+            body.classList.add('lang-bg'); // General class for styling shared background properties
+
         } else {
-            body.classList.add('no-language-selected-bg');
+            // If no language is selected (e.g., placeholder is chosen),
+            // ensure specific language class is removed (handled by classesToRemove)
+            // and apply a default or "no language" state if desired.
+            body.classList.add('no-language-selected-bg'); // This class can define a specific look for when no language is chosen.
+                                                            // If not defined, default body styles will apply.
         }
     }, [currentLangKey, allTranslations]); // Added allTranslations to dependency array
 


### PR DESCRIPTION
I modified `src/components/Freestyle/LanguageSelectorFreestyle.js` to remove the problematic `classExists` JavaScript check before applying language-specific background classes to the body element.

The component now unconditionally adds the `[langKey]-bg` and `lang-bg` classes when a language is selected. This simplifies the logic and makes the class application more robust, relying on the browser to ignore undefined CSS classes if any were to occur.

This change directly addresses an issue where the `classExists` check was likely failing (especially with non-ASCII characters in class names or CSS loading timing issues), preventing the correct flag background from being displayed.