### PR TITLE
Debug: Add lime border to body for testing CSS application

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,13 @@ body {
   display: flex; /* Ensure body takes full height for sticky footer */
   flex-direction: column; /* Ensure body takes full height for sticky footer */
   min-height: 100vh; /* Ensure body takes full height for sticky footer */
+  /* Keeping the gradient from the old CSS as a base or fallback */
+  background-image: linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%);
+  background-attachment: fixed;
+  background-size: cover;
+  background-position: center center;
+  background-repeat: no-repeat;
+  border: 20px solid lime !important; /* MINIMAL TEST */
 }
 
 img, picture, video, canvas, svg {
@@ -313,16 +320,6 @@ h4 { font-size: var(--font-size-h4); }
 /* etc. for more spacing utilities */
 
 /* Language Flag Backgrounds */
-/* Default body background - can be overridden by language-specific classes */
-body {
-  /* Keeping the gradient from the old CSS as a base or fallback */
-  background-image: linear-gradient(135deg, #00bdbd 0%, #1de9b6 60%, #ffe082 100%);
-  background-attachment: fixed;
-  background-size: cover;
-  background-position: center center;
-  background-repeat: no-repeat;
-}
-
 /* Base for language-specific backgrounds */
 .lang-bg {
   background-attachment: fixed !important;


### PR DESCRIPTION
Added a temporary `border: 20px solid lime !important;` to the body rule in `src/index.css`.

This is a diagnostic step to help determine if `src/index.css` is being loaded and its styles are being applied to the body element when the application is run in your local environment.