### PR TITLE
Fix: Ensure global styles are applied to freestyle.html

### DIFF
--- a/src/islands/freestyleIslandsEntry.js
+++ b/src/islands/freestyleIslandsEntry.js
@@ -18,6 +18,7 @@ import HelpPopupIsland from '../components/Freestyle/HelpPopupIsland'; // Import
 import { allMenuItemsConfig as fullMenuConfig } from '../utils/menuNavigationLogic';
 
 // Styles
+import '../../index.css'; // Import global styles
 import '../components/LanguageSelector/LanguageSelector.css';
 import '../components/Freestyle/DaySelectorFreestyle.css';
 import '../components/Freestyle/PracticeCategoryNav.css';


### PR DESCRIPTION
Previously, freestyle.html (via freestyleIslandsEntry.js) was not importing src/index.css, leading to a white screen due to missing base styles and CSS variables.

This commit adds the import for src/index.css into src/islands/freestyleIslandsEntry.js, allowing global styles to be correctly applied to the freestyle page. Freestyle-specific styles remain in freestyle-shared.css.