### PR TITLE
Fix: Correct import path for index.css and ensure build passes

### DIFF
--- a/src/islands/freestyleIslandsEntry.js
+++ b/src/islands/freestyleIslandsEntry.js
@@ -18,7 +18,7 @@ import HelpPopupIsland from '../components/Freestyle/HelpPopupIsland'; // Import
 import { allMenuItemsConfig as fullMenuConfig } from '../utils/menuNavigationLogic';
 
 // Styles
-import '../../index.css'; // Import global styles
+import '../index.css'; // Import global styles
 import '../components/LanguageSelector/LanguageSelector.css';
 import '../components/Freestyle/DaySelectorFreestyle.css';
 import '../components/Freestyle/PracticeCategoryNav.css';


### PR DESCRIPTION
- Corrected the import path for `index.css` in `src/islands/freestyleIslandsEntry.js` to `../index.css` to resolve CRA build error.
- Ensured dependencies are installed for the build process.

This commit follows the previous one on the same branch that initially added the import to fix styling on freestyle.html.