### PR TITLE
feat: reorganize exercises and add study mode button

### DIFF
--- a/src/components/Freestyle/ExerciseHost.js
+++ b/src/components/Freestyle/ExerciseHost.js
@@ -111,9 +111,13 @@ const exerciseMap = {
   'writing_storytelling_exercise': StorytellingExercise,
   'writing_diary_exercise': DiaryPracticeExercise,
 
-  // General Listening (if directly selected as a category)
-  'listening': ListeningPracticeHost,
+  // General Listening (if directly selected as a category) - Obsolete, now under vocabulary
+  // 'listening': ListeningPracticeHost,
   'possessives': () => <PlaceholderExercise name="Possessives" subPracticeType="possessives" />, // Placeholder
+
+  // New Vocabulary mappings based on user feedback
+  'vocabulary_listening': ListeningPracticeHost,
+  'vocabulary_practice_all': PracticeAllVocabHost,
 };
 
 const ExerciseHost = ({ subPracticeType, language, days, exerciseKey }) => {

--- a/src/components/Freestyle/freestyle-shared.css
+++ b/src/components/Freestyle/freestyle-shared.css
@@ -56,6 +56,26 @@
   max-width: 400px; /* Match selector width */
 }
 
+/* Button to switch from Freestyle to Study Mode */
+.study-mode-switch-btn {
+  background-color: var(--color-secondary, #6c757d);
+  color: var(--color-text-on-dark, white);
+  padding: var(--spacing-sm, 8px) var(--spacing-md, 15px);
+  border-radius: var(--border-radius-md, 6px);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: var(--font-size-base, 1rem);
+  box-shadow: var(--shadow-sm, 0 2px 4px rgba(0,0,0,0.075));
+  cursor: pointer;
+  border: none;
+  transition: background-color 0.2s ease-in-out, transform 0.15s ease;
+  margin-top: var(--spacing-md, 1rem); /* Add some space above it */
+}
+
+.study-mode-switch-btn:hover {
+  background-color: var(--color-secondary-dark, #545b62);
+  transform: translateY(-1px);
+}
 
 .study-mode-button {
   background-color: var(--color-primary, #007bff);

--- a/src/i18n/translationsData.js
+++ b/src/i18n/translationsData.js
@@ -29,15 +29,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -148,7 +151,8 @@ const translations = {
       title: "Manage Your Study Sets",
       backToList: "← Back to Set List",
       errorSetNotFoundForPlayer: "Could not find the set to study. It may have been deleted."
-    }
+    },
+    switchToStudyMode: "Study Mode"
   },
   COSYfrench: { // Standardized: COSY + french
     greeting: "Bonjour",
@@ -177,15 +181,18 @@ const translations = {
     // practiceAll: "🔁 Tout Pratiquer", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Pratique de Conjugaison"
+        grammar_conjugation_practice: "Pratique de Conjugaison",
+        sentence_unscramble_exercise: "Remettre la Phrase en Ordre",
+        fill_in_the_blanks_exercise: "Compléter les Trous"
       },
       vocabulary: {
         vocabulary_random_word_image: "Mot/Image Aléatoire",
         vocabulary_opposites_match: "Contraires/Associer",
         vocabulary_letters_scramble: "Lettres",
-        vocabulary_true_false: "Vrai/Faux"
+        vocabulary_true_false: "Vrai/Faux",
+        vocabulary_listening: "Écoute",
+        vocabulary_practice_all: "Tout Pratiquer"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Remettre la Phrase en Ordre",
@@ -296,7 +303,8 @@ const translations = {
       title: "Gérer Vos Decks d'Étude",
       backToList: "← Retour à la Liste des Decks",
       errorSetNotFoundForPlayer: "Impossible de trouver le deck à étudier. Il a peut-être été supprimé."
-    }
+    },
+    switchToStudyMode: "Mode Étude"
   },
   COSYitalian: { // Standardized: COSY + italian (was COSYitaliano)
     languageNameInEnglish: "Italian",
@@ -327,15 +335,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -477,15 +488,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -627,15 +641,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -777,15 +794,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -927,15 +947,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -1077,15 +1100,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -1227,15 +1253,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -1377,15 +1406,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -1527,15 +1559,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -1677,15 +1712,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",
@@ -1827,15 +1865,18 @@ const translations = {
     // practiceAll: "🔁 Practice All", // Removed as a main category
     subPractice: {
       grammar: {
-        grammar_conjugation_practice: "Conjugation Practice"
+        grammar_conjugation_practice: "Conjugation Practice",
+        sentence_unscramble_exercise: "Sentence Unscramble",
+        fill_in_the_blanks_exercise: "Fill in the Blanks"
       },
       vocabulary: {
         vocabulary_random_word_image: "Random Word/Image",
         vocabulary_opposites_match: "Opposites/Match It",
         vocabulary_letters_scramble: "Letters",
-        vocabulary_true_false: "True/False"
+        vocabulary_true_false: "True/False",
+        vocabulary_listening: "Listening",
+        vocabulary_practice_all: "Practice All"
       }
-      // sentenceSkills block removed
     },
     sentenceUnscramble: {
       title: "Unscramble the Sentence",

--- a/src/islands/freestyleIslandsEntry.js
+++ b/src/islands/freestyleIslandsEntry.js
@@ -43,6 +43,14 @@ export const LanguageIslandApp = () => {
 
   const showToast = (message, duration = 2500) => { setToast(message); setTimeout(() => setToast(null), duration); };
 
+  // Placeholder for navigation until react-router is integrated into this island
+  const navigateToStudyMode = () => {
+    // In a full SPA with React Router, this would be: navigate('/study');
+    // For freestyle.html, we redirect to the main app's study page.
+    // Assuming the main app is at the root and handles /study route.
+    window.location.href = '/study';
+  };
+
   const handleLanguageChangeForIsland = (newLanguage) => {
     // Prevent processing if the new language is null, undefined, or empty, or same as current
     if (!newLanguage || selectedLanguage === newLanguage) {
@@ -91,6 +99,9 @@ export const LanguageIslandApp = () => {
         </label>
         <LanguageSelectorFreestyle selectedLanguage={selectedLanguage} onLanguageChange={handleLanguageChangeForIsland} />
         <ToggleLatinizationButton currentDisplayLanguage={selectedLanguage} />
++        <button onClick={navigateToStudyMode} className="study-mode-switch-btn">
++          {t('switchToStudyMode', 'Study Mode')}
++        </button>
       </div>
       {toast && <div className="cosy-toast">{toast}</div>}
     </>

--- a/src/utils/menuNavigationLogic.js
+++ b/src/utils/menuNavigationLogic.js
@@ -61,18 +61,21 @@ export const allMenuItemsConfig = {
       'vocabulary_random_word_image',
       'vocabulary_opposites_match',
       'vocabulary_letters_scramble',
-      'vocabulary_true_false'
+      'vocabulary_true_false',
+      'vocabulary_listening',
+      'vocabulary_practice_all'
     ]
   },
   'grammar': {
     parent: 'main_practice_categories_stage',
-    // Children can be refined or kept if they are still relevant under "Grammar"
     children: [
       'grammar_fill_gaps_exercise',
       'grammar_type_verb_exercise',
       'grammar_select_article_exercise',
       'grammar_word_order_exercise',
-      'grammar_conjugation_practice'
+      'grammar_conjugation_practice',
+      'sentence_unscramble_exercise',
+      'fill_in_the_blanks_exercise'
     ]
   },
   'reading': {
@@ -107,6 +110,8 @@ export const allMenuItemsConfig = {
   // 'vocab_type_opposite_exercise': { parent: 'vocabulary', isExercise: true },
   // 'vocab_build_word_exercise': { parent: 'vocabulary', isExercise: true },
   // 'vocab_practice_all_sub_host': { parent: 'vocabulary', isExercise: true },
+  'vocabulary_listening': { parent: 'vocabulary', isExercise: true, i18nKey: 'subPractice.vocabulary.vocabulary_listening' }, // Maps to ListeningPracticeHost
+  'vocabulary_practice_all': { parent: 'vocabulary', isExercise: true, i18nKey: 'subPractice.vocabulary.vocabulary_practice_all' }, // Maps to PracticeAllVocabHost
 
   // Grammar Sub-Practice Exercises (Leaf nodes)
   'grammar_fill_gaps_exercise': { parent: 'grammar', isExercise: true },
@@ -114,6 +119,8 @@ export const allMenuItemsConfig = {
   'grammar_select_article_exercise': { parent: 'grammar', isExercise: true },
   'grammar_word_order_exercise': { parent: 'grammar', isExercise: true },
   'grammar_conjugation_practice': { parent: 'grammar', isExercise: true, i18nKey: 'subPractice.grammar.grammar_conjugation_practice' },
+  'sentence_unscramble_exercise': { parent: 'grammar', isExercise: true, i18nKey: 'subPractice.grammar.sentence_unscramble_exercise' },
+  'fill_in_the_blanks_exercise': { parent: 'grammar', isExercise: true, i18nKey: 'subPractice.grammar.fill_in_the_blanks_exercise' },
 
   // Reading Sub-Practice Exercises (Leaf nodes)
   'reading_story_exercise': { parent: 'reading', isExercise: true },


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Adds a 'Switch to Study Mode' button** to the Freestyle mode page (`freestyle.html`).
    *   The button is added to the `LanguageIslandApp` component for consistent visibility.
    *   It uses a `window.location.href` redirect to navigate to the `/study` path, which is appropriate for moving from a static page to a route within the main SPA.
    *   New i18n keys and CSS have been added for the button.

2.  **Reorganizes Exercise Categories** based on your feedback:
    *   The main practice categories are now strictly: Vocabulary, Grammar, Reading, Speaking, and Writing.
    *   Exercises formerly under "Sentence Skills" (`Sentence Unscramble`, `Fill in the Blanks`) have been moved under the "Grammar" category.
    *   "Listening" has been added as a sub-category under "Vocabulary".
    *   "Practice All" has been added as a sub-category under "Vocabulary".
    *   `menuNavigationLogic.js` has been updated to reflect this new hierarchy, with `parent` properties of moved exercises corrected.
    *   `translationsData.js` has been updated to move i18n keys to their new sub-practice locations (`subPractice.grammar` and `subPractice.vocabulary`).
    *   `ExerciseHost.js` mappings have been updated to include the new vocabulary sub-types.