### PR TITLE
I've fixed an ESLint unused variable error in the `PracticeNavIslandA…

### DIFF
--- a/src/islands/freestyleIslandsEntry.js
+++ b/src/islands/freestyleIslandsEntry.js
@@ -155,7 +155,7 @@ export const PracticeNavIslandApp = ({ language, days }) => {
   const localNavMenuConfig = fullMenuConfig;
 
   const activeStage = navPath[navPath.length - 1];
-  const activeMainCatKey = navPath.includes('vocabulary') ? 'vocabulary' : navPath.includes('grammar') ? 'grammar' : navPath.includes('reading') ? 'reading' : navPath.includes('speaking') ? 'speaking' : navPath.includes('writing') ? 'writing' : null;
+  // const activeMainCatKey = navPath.includes('vocabulary') ? 'vocabulary' : navPath.includes('grammar') ? 'grammar' : navPath.includes('reading') ? 'reading' : navPath.includes('speaking') ? 'speaking' : navPath.includes('writing') ? 'writing' : null; // This is no longer needed for visibility logic
 
   const localIsMenuItemVisible = (path, itemKey, config) => {
     const currentActiveStage = path[path.length - 1];


### PR DESCRIPTION
…pp`.

I commented out the `activeMainCatKey` variable in the `PracticeNavIslandApp` component within `src/islands/freestyleIslandsEntry.js`.

This variable was a remnant of a previous navigation logic and was no longer used after refactoring to a path-based state management system, causing the production build to fail due to the `no-unused-vars` ESLint rule.