### PR TITLE
fix: implement SPA redirect handler for GitHub Pages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,18 @@ import { LatinizationProvider } from './contexts/LatinizationContext';
 import { UserProfileProvider } from './contexts/UserProfileContext'; // Added UserProfileProvider
 import './index.css'; 
 
+// --- SPA Redirect Logic for GitHub Pages ---
+// This checks if the URL has a `p` query parameter, which our 404.html page sets.
+// If it does, it rewrites the URL to the correct path and replaces the history state.
+// This allows React Router to handle routes correctly on refresh or direct navigation.
+const params = new URLSearchParams(window.location.search);
+const redirectPath = params.get('p');
+if (redirectPath) {
+  const newUrl = window.location.pathname.replace(/\/?$/, '') + redirectPath + window.location.hash;
+  window.history.replaceState(null, '', newUrl);
+}
+// --- End of SPA Redirect Logic ---
+
 const rootElement = document.getElementById('root');
 const isProd = process.env.NODE_ENV === 'production';
 


### PR DESCRIPTION
Adds a script to `src/index.js` to handle redirects from the custom `404.html` page. This script checks for a `p` query parameter in the URL (e.g., `?p=/study`), which is set by the 404 page, and uses the History API to rewrite the URL to the correct path that React Router can understand.

This fixes the issue where direct navigation or refreshing a nested route (like `/study`) on GitHub Pages would result in a 404 error.