### PR TITLE
Fix: Create useIrregularVerbs hook and correct import path

### DIFF
--- a/src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js
+++ b/src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import IrregularVerbLevelSelector from './IrregularVerbLevelSelector';
-import useIrregularVerbs from '../../hooks/useIrregularVerbs';
+import useIrregularVerbs from '../../../hooks/useIrregularVerbs.js';
 import IrregularVerbQuiz from '../exercises/grammar/IrregularVerbQuiz';
 import FillLettersExercise from './FillLettersExercise';
 import FillBlanksExercise from './FillBlanksExercise';

--- a/src/hooks/useIrregularVerbs.js
+++ b/src/hooks/useIrregularVerbs.js
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+const useIrregularVerbs = (levels, variety) => {
+    const [verbs, setVerbs] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchVerbs = async () => {
+            try {
+                const response = await fetch('/data/grammar/verbs/irregular_verbs.json');
+                if (!response.ok) {
+                    throw new Error('Failed to fetch irregular verbs');
+                }
+                const allVerbs = await response.json();
+
+                // Filter verbs based on levels and variety if provided
+                let filteredVerbs = allVerbs;
+                if (levels) {
+                    const levelSet = new Set(levels.split(','));
+                    filteredVerbs = filteredVerbs.filter(verb => levelSet.has(verb.level));
+                }
+                if (variety) {
+                    filteredVerbs = filteredVerbs.filter(verb => verb.variety === variety);
+                }
+
+                setVerbs(filteredVerbs);
+            } catch (err) {
+                setError(err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchVerbs();
+    }, [levels, variety]);
+
+    return { verbs, loading, error };
+};
+
+export default useIrregularVerbs;


### PR DESCRIPTION
- I created the `useIrregularVerbs.js` hook in `src/hooks` to fetch irregular verbs data.
- I corrected the import path in `src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js` to resolve the module not found error.
- The application now builds successfully.