### PR TITLE
Fix: Correct studymode redirect and add PIN modal message

### DIFF
--- a/src/components/Common/PinModal.js
+++ b/src/components/Common/PinModal.js
@@ -16,6 +16,7 @@ const PinModal = ({ onSubmit, onClose, error }) => {
     <div className="modal-overlay"> {/* Changed from modal-backdrop */}
       <div className="modal-content pin-modal-content">
         <h2>{t('pinPromptMessage', 'Enter PIN for Study Mode')}</h2>
+        <p>Please enter the PIN to access the study mode. If you do not have a PIN, please contact the administrator.</p>
         <form onSubmit={handleSubmit}>
           <input
             type="password"

--- a/src/islands/freestyleIslandsEntry.js
+++ b/src/islands/freestyleIslandsEntry.js
@@ -48,7 +48,7 @@ export const LanguageIslandApp = () => {
     // In a full SPA with React Router, this would be: navigate('/study');
     // For freestyle.html, we redirect to the main app's study page.
     // Assuming the main app is at the root and handles /study route.
-    window.location.href = '/study';
+    window.location.href = '/COSYlanguagesproject/study';
   };
 
   const handleLanguageChangeForIsland = (newLanguage) => {


### PR DESCRIPTION
- I corrected the redirect URL for the study mode button in `freestyle.html` to correctly navigate to the study mode page.
- I added a descriptive message to the PIN modal to inform you that a PIN is required to access the study mode.