### PR TITLE
Feat: Add Freestyle button to Study Mode page

### DIFF
--- a/src/pages/StudyModePage/StudyModePage.js
+++ b/src/pages/StudyModePage/StudyModePage.js
@@ -12,6 +12,7 @@ import LessonSectionsPanel from '../../components/StudyMode/LessonSectionsPanel'
 import ToolsPanel from '../../components/StudyMode/ToolsPanel';
 import TransliterableText from '../../components/Common/TransliterableText';
 import ToggleLatinizationButton from '../../components/Common/ToggleLatinizationButton';
+import Button from '../../components/Common/Button';
 
 import './StudyModePage.css';
 
@@ -304,6 +305,9 @@ const StudyModePage = () => {
         <ToggleLatinizationButton
           currentDisplayLanguage={currentLangKey || language}
         />
+        <Button onClick={() => window.location.href = '/COSYlanguagesproject/freestyle.html'}>
+          Freestyle
+        </Button>
       </div>
 
       <div className="study-menu-section">


### PR DESCRIPTION
- Added a 'Freestyle' button to the Study Mode page to allow you to easily navigate back to the freestyle mode.
- Imported the `Button` component into the `StudyModePage.js` file.