### PR TITLE
Fix: Correct file path for irregular verbs data

### DIFF
--- a/src/hooks/useIrregularVerbs.js
+++ b/src/hooks/useIrregularVerbs.js
@@ -8,7 +8,7 @@ const useIrregularVerbs = (levels, variety) => {
     useEffect(() => {
         const fetchVerbs = async () => {
             try {
-                const response = await fetch('/data/grammar/verbs/irregular_verbs.json');
+                const response = await fetch('/data/grammar/verbs/irregular/irregular_verbs.json');
                 if (!response.ok) {
                     throw new Error('Failed to fetch irregular verbs');
                 }


### PR DESCRIPTION
- Corrected the file path for the irregular verbs data in the `useIrregularVerbs` hook to point to the correct location.