### PR TITLE
Fix: a white screen on initial load

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -21,9 +21,7 @@ module.exports = {
           template: paths.appHtml, // public/index.html
           filename: 'index.html',
           chunks: ['main'], // Only include the main bundle related chunks
-          // Ensure other CRA defaults are preserved if needed (e.g. favicon, manifest)
-          // We might need to explicitly pass publicPath, etc. if CRA's default plugin did.
-          // For simplicity, starting with minimal options.
+          publicPath: env === 'production' ? '/COSYlanguagesproject/' : '/',
         })
       );
 
@@ -34,6 +32,7 @@ module.exports = {
           template: path.resolve(__dirname, 'public/freestyle.html'),
           filename: 'freestyle.html',
           chunks: ['freestyle'], // Only include the freestyle bundle related chunks
+          publicPath: env === 'production' ? '/COSYlanguagesproject/' : '/',
         })
       );
 


### PR DESCRIPTION
This commit fixes an issue where the application would show a white screen on the initial load. The problem was caused by the `HtmlWebpackPlugin` not having the correct `publicPath` set.

The fix explicitly sets the `publicPath` in `craco.config.js` for both `index.html` and `freestyle.html`. This ensures that the generated HTML files have the correct paths to the JavaScript and CSS bundles, which should resolve the white screen issue.