### PR TITLE
Fix: study mode redirect loop

### DIFF
--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -35,18 +35,17 @@ const StudyModeProtectedRoute = ({ children }) => {
 
     const handleModalClose = () => {
         setShowPinModal(false);
-        navigate('/');
+        // We don't navigate away, just close the modal.
+        // The user can then try to navigate to /study again if they wish.
     }
 
     if (isPinVerified) {
         return children;
     }
 
-    if (showPinModal) {
-        return <PinModal onSubmit={handlePinSubmit} onClose={handleModalClose} error={t('auth.incorrectPin', pinError)} />;
-    }
-
-    return <Navigate to="/" replace />;
+    // If not verified, always show the PIN modal.
+    // The conditional rendering of the modal is handled inside this component's logic.
+    return <PinModal onSubmit={handlePinSubmit} onClose={handleModalClose} error={pinError} />;
 };
 
 // ProtectedRoute for general authentication (if needed for pages like MyStudySetsPage)


### PR DESCRIPTION
This commit fixes an issue where the study mode would get stuck in a redirect loop. The problem was caused by the `StudyModeProtectedRoute` component redirecting to the root path when the PIN modal was closed.

The fix removes the redirect and instead just closes the modal. This allows you to enter the PIN without being redirected.