### PR TITLE
Fix: Correct homepage URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://cosylanguages.github.io/COSYlanguagesproject/",
+  "homepage": "https://cosylanguages.github.io/",
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
- The `homepage` field was pointing to the wrong URL, causing a 404 error on deployment.
- This has been corrected to point to the correct GitHub Pages URL.