### PR TITLE
Feat: Implement language-specific pages

### DIFF
--- a/src/components/StudyMode/StudentTools/IrregularVerbsTool.js
+++ b/src/components/StudyMode/StudentTools/IrregularVerbsTool.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { useI18n } from '../../../i18n/I18nContext';
 import useVerbs from '../../../hooks/useVerbs';
 import SearchableCardList from '../../Common/SearchableCardList';
 import IrregularVerbCard from './IrregularVerbCard';

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ import './components/Common/animations.css';
 
 
 const rootElement = document.getElementById('root');
-const isProd = process.env.NODE_ENV === 'production';
 
 if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);


### PR DESCRIPTION
This commit introduces language-specific pages for the study mode. This improves performance by only loading the data for the selected language, and it also makes the application more scalable and easier to maintain.

The key changes are:

- The application's routing has been updated to include the language code in the URL.
- The `LanguageSelector` component has been updated to navigate to the new language-specific URLs.
- The `DictionaryTool` and `IrregularVerbsTool` have been updated to use the `lang` parameter from the URL to fetch the correct data.