### PR TITLE
fix: Allow 'self' in service worker

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "COSY",
+  "name": "COSYlanguages",
   "icons": [
     {
       "src": "favicon.ico",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,16 @@
     "extends": [
       "react-app",
       "react-app/jest"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "src/sw.js"
+        ],
+        "rules": {
+          "no-restricted-globals": "off"
+        }
+      }
     ]
   },
   "browserslist": {


### PR DESCRIPTION
The `no-restricted-globals` ESLint rule was preventing the use of `self` in the service worker file (`src/sw.js`), which is necessary for service worker functionality. This change adds an override to the ESLint configuration in `package.json` to disable this rule for the service worker file, allowing the project to build successfully.