### PR TITLE
fix: Remove publicPath from craco.config.js

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -22,7 +22,6 @@ module.exports = {
           filename: 'index.html',
           chunks: ['main'], // Only include the main bundle related chunks
           excludeChunks: ['sw'], // Exclude the service worker
-          publicPath: env === 'production' ? '/COSYlanguagesproject/' : '/',
         })
       );
 


### PR DESCRIPTION
The `publicPath` configuration in `craco.config.js` was causing incorrect asset paths in the production build, leading to 404 errors on reload. This commit removes the `publicPath` configuration, allowing the `homepage` field in `package.json` to correctly control the asset paths.