### PR TITLE
fix: Set segmentCount to 1 in 404.html

### DIFF
--- a/build/404.html
+++ b/build/404.html
@@ -15,7 +15,7 @@
       // Note: The static assets in the repo (i.e. css, js, images, etc.)
       // must be loaded with absolute paths, such as /repo-name/path/to/asset.js
       // or http://user.github.io/repo-name/path/to/asset.js
-      var segmentCount = 0;
+      var segmentCount = 1;
       var l = window.location;
       l.replace(
         l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +

--- a/public/404.html
+++ b/public/404.html
@@ -15,7 +15,7 @@
       // Note: The static assets in the repo (i.e. css, js, images, etc.)
       // must be loaded with absolute paths, such as /repo-name/path/to/asset.js
       // or http://user.github.io/repo-name/path/to/asset.js
-      var segmentCount = 0;
+      var segmentCount = 1;
       var l = window.location;
       l.replace(
         l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +


### PR DESCRIPTION
The `404.html` redirect script for GitHub Pages was not working correctly because the `segmentCount` was not set correctly for the repository's path. This commit sets the `segmentCount` to `1` to ensure that the redirect script works correctly.