### PR TITLE
fix: Revert changes and set homepage

### DIFF
--- a/build/404.html
+++ b/build/404.html
@@ -2,31 +2,67 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Single Page Apps for GitHub Pages</title>
+    <title>Redirecting...</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages
       // MIT License
       // https://github.com/rafgraph/spa-github-pages
       // This script takes the current url and converts the path and query
       // string into just a query string, and then redirects the browser
-      // to the new url with the new query string and an empty path.
-      // For example, https://user.github.io/repo-name/one/two?a=b&c=d#qwe
-      // would be redirected to https://user.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
-      // Note: The static assets in the repo (i.e. css, js, images, etc.)
-      // must be loaded with absolute paths, such as /repo-name/path/to/asset.js
-      // or http://user.github.io/repo-name/path/to/asset.js
-      var segmentCount = 1;
-      var l = window.location;
-      l.replace(
-        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-        l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?/' +
-        l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
-        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-        l.hash
-      );
+      // to the new url with only a query string and hash fragment,
+      // e.g. http://user.github.io/repo/?p=/some/path&q=X#hash
+      // Note: this 404.html file must be at least 512 bytes for Internet Explorer to display it.
+
+      (function() {
+        var l = window.location;
+        // Correctly determine the basename from the script tag.
+        // This makes the script more portable and less dependent on hardcoded values.
+        var SCRIPT_NAME = 'spa-github-pages-script';
+        var script = document.getElementById(SCRIPT_NAME);
+        // The script src will be like "https://user.github.io/repo/404.html" or "/repo/404.html"
+        // We want to extract the "/repo" part.
+        var path = script.src.substring(l.origin.length, script.src.lastIndexOf('/'));
+
+        var segmentCount = path.startsWith('/') ? path.split('/').length -1 : 0;
+
+        var newPath = l.pathname.slice(1).split('/').slice(segmentCount).join('/');
+        var newSearch = l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '';
+        var newHash = l.hash;
+
+        var baseDir = path + '/';
+
+        var redirectTo = l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+                         baseDir +
+                         '?p=/' + newPath +
+                         newSearch +
+                         newHash;
+
+        l.replace(redirectTo);
+      })();
 
     </script>
   </head>
   <body>
+    <!-- IE requires 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
   </body>
 </html>

--- a/craco.config.js
+++ b/craco.config.js
@@ -22,6 +22,7 @@ module.exports = {
           filename: 'index.html',
           chunks: ['main'], // Only include the main bundle related chunks
           excludeChunks: ['sw'], // Exclude the service worker
+          publicPath: env === 'production' ? '/COSYlanguagesproject/' : '/',
         })
       );
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
-  "homepage": "./",
+  "homepage": "https://cosylanguages.github.io/COSYlanguagesproject/",
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/public/404.html
+++ b/public/404.html
@@ -2,31 +2,67 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Single Page Apps for GitHub Pages</title>
+    <title>Redirecting...</title>
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages
       // MIT License
       // https://github.com/rafgraph/spa-github-pages
       // This script takes the current url and converts the path and query
       // string into just a query string, and then redirects the browser
-      // to the new url with the new query string and an empty path.
-      // For example, https://user.github.io/repo-name/one/two?a=b&c=d#qwe
-      // would be redirected to https://user.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
-      // Note: The static assets in the repo (i.e. css, js, images, etc.)
-      // must be loaded with absolute paths, such as /repo-name/path/to/asset.js
-      // or http://user.github.io/repo-name/path/to/asset.js
-      var segmentCount = 1;
-      var l = window.location;
-      l.replace(
-        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
-        l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?/' +
-        l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
-        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
-        l.hash
-      );
+      // to the new url with only a query string and hash fragment,
+      // e.g. http://user.github.io/repo/?p=/some/path&q=X#hash
+      // Note: this 404.html file must be at least 512 bytes for Internet Explorer to display it.
+
+      (function() {
+        var l = window.location;
+        // Correctly determine the basename from the script tag.
+        // This makes the script more portable and less dependent on hardcoded values.
+        var SCRIPT_NAME = 'spa-github-pages-script';
+        var script = document.getElementById(SCRIPT_NAME);
+        // The script src will be like "https://user.github.io/repo/404.html" or "/repo/404.html"
+        // We want to extract the "/repo" part.
+        var path = script.src.substring(l.origin.length, script.src.lastIndexOf('/'));
+
+        var segmentCount = path.startsWith('/') ? path.split('/').length -1 : 0;
+
+        var newPath = l.pathname.slice(1).split('/').slice(segmentCount).join('/');
+        var newSearch = l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '';
+        var newHash = l.hash;
+
+        var baseDir = path + '/';
+
+        var redirectTo = l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+                         baseDir +
+                         '?p=/' + newPath +
+                         newSearch +
+                         newHash;
+
+        l.replace(redirectTo);
+      })();
 
     </script>
   </head>
   <body>
+    <!-- IE requires 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
+    <!--                                                                          -->
   </body>
 </html>


### PR DESCRIPTION
This commit reverts the changes to `public/404.html` and `craco.config.js` and sets the `homepage` in `package.json` to the explicit URL of the GitHub pages site. This should resolve the routing and build issues.