### PR TITLE
fix: Register sw with correct path and fix publicPath

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -22,7 +22,7 @@ module.exports = {
           filename: 'index.html',
           chunks: ['main'], // Only include the main bundle related chunks
           excludeChunks: ['sw'], // Exclude the service worker
-          publicPath: env === 'production' ? '/COSYlanguagesproject/' : '/',
+          publicPath: env === 'production' ? '' : '/',
         })
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,8 @@ if (rootElement) {
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').then(registration => {
+    const swUrl = `${process.env.PUBLIC_URL}/sw.js`;
+    navigator.serviceWorker.register(swUrl).then(registration => {
       console.log('SW registered: ', registration);
     }).catch(registrationError => {
       console.log('SW registration failed: ', registrationError);


### PR DESCRIPTION
This commit fixes the service worker registration path in `src/index.js` and sets the `publicPath` in `craco.config.js` to an empty string in production. This should resolve the 404 errors for the service worker and manifest, and allow the application to load correctly.