### PR TITLE
fix: Set basename of BrowserRouter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <BrowserRouter>
+      <BrowserRouter basename="/COSYlanguagesproject">
         <I18nProvider>
           <LatinizationProvider>
             <AuthProvider>


### PR DESCRIPTION
This commit sets the `basename` of the `BrowserRouter` in `src/index.js` to `/COSYlanguagesproject/`. This will ensure that the routing works correctly on GitHub Pages.