### PR TITLE
fix: Configure routing for gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://cosylanguages.github.io/COSYlanguagesproject/",
+  "homepage": "/COSYlanguagesproject/",
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <BrowserRouter basename="/COSYlanguagesproject">
+      <BrowserRouter>
         <I18nProvider>
           <LatinizationProvider>
             <AuthProvider>


### PR DESCRIPTION
This commit configures the routing for GitHub Pages by removing the `basename` from the `BrowserRouter` in `src/index.js` and setting the `homepage` in `package.json` to `/COSYlanguagesproject/`. This should resolve the routing issues and allow the application to load correctly.