### PR TITLE
feat: Fix island architecture implementation

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -13,7 +13,7 @@ module.exports = {
       webpackConfig.entry = {
         main: paths.appIndexJs,
         sw: './src/sw.js', // Added service worker entry point
-        study: './src/pages/StudyModePage/StudyModePage.js', // Added study mode entry point
+        study: './src/StudyRoutes.js', // Added study mode entry point
         ...languageEntries,
       };
 

--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 // import { usePlan } from './contexts/PlanContext'; // Commented out as PlanOverview is commented
 import { useAuth } from './contexts/AuthContext';
 import { useI18n } from './i18n/I18nContext';
@@ -23,8 +23,14 @@ const ProtectedRoute = ({ children }) => {
 
 
 function AppRoutes() {
-    const { isAuthenticated, loadingAuth } = useAuth();
-    const { t } = useI18n(); // For loading message translation
+    return (
+        <BrowserRouter>
+            <App />
+        </BrowserRouter>
+    );
+}
+
+function App() {
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -38,18 +44,6 @@ function AppRoutes() {
             window.removeEventListener('navigateTo', handleNavigate);
         };
     }, [navigate]);
-
-    // Define the catch-all element logic
-    let catchAllElement;
-    if (loadingAuth) {
-        catchAllElement = <div>{t('auth.loadingStatus', 'Loading authentication status...')}</div>;
-    } else if (isAuthenticated) {
-        // Authenticated users hitting an unknown SPA path go to the SPA root
-        catchAllElement = <Navigate to="/" replace />;
-    } else {
-        // Unauthenticated users hitting an unknown SPA path go to the login page
-        catchAllElement = <Navigate to="/login" replace />;
-    }
 
     return (
         <Routes>
@@ -77,9 +71,24 @@ function AppRoutes() {
                 </Route>
             </Route>
             {/* Catch-all route */}
-            <Route path="*" element={catchAllElement} />
+            <Route path="*" element={<CatchAll />} />
         </Routes>
     );
+}
+
+function CatchAll() {
+    const { isAuthenticated, loadingAuth } = useAuth();
+    const { t } = useI18n(); // For loading message translation
+
+    if (loadingAuth) {
+        return <div>{t('auth.loadingStatus', 'Loading authentication status...')}</div>;
+    } else if (isAuthenticated) {
+        // Authenticated users hitting an unknown SPA path go to the SPA root
+        return <Navigate to="/" replace />;
+    } else {
+        // Unauthenticated users hitting an unknown SPA path go to the login page
+        return <Navigate to="/login" replace />;
+    }
 }
 
 export default AppRoutes;

--- a/src/StudyRoutes.js
+++ b/src/StudyRoutes.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import StudyModePage from './pages/StudyModePage/StudyModePage';
+
+function StudyRoutes() {
+    return (
+        <BrowserRouter basename="/COSYlanguagesproject/study">
+            <Routes>
+                <Route path="/" element={<Navigate to="/en" replace />} />
+                <Route path="/:lang" element={<StudyModePage />} />
+            </Routes>
+        </BrowserRouter>
+    );
+}
+
+export default StudyRoutes;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import AppRoutes from './AppRoutes';
 import { PlanProvider } from './contexts/PlanContext';
 import { AuthProvider } from './contexts/AuthContext';
@@ -17,19 +16,17 @@ if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <BrowserRouter>
-        <I18nProvider>
-          <LatinizationProvider>
-            <AuthProvider>
-              <UserProfileProvider>
-                <PlanProvider>
-                  <AppRoutes />
-                </PlanProvider>
-              </UserProfileProvider>
-            </AuthProvider>
-          </LatinizationProvider>
-        </I18nProvider>
-      </BrowserRouter>
+      <I18nProvider>
+        <LatinizationProvider>
+          <AuthProvider>
+            <UserProfileProvider>
+              <PlanProvider>
+                <AppRoutes />
+              </PlanProvider>
+            </UserProfileProvider>
+          </AuthProvider>
+        </LatinizationProvider>
+      </I18nProvider>
     </React.StrictMode>
   );
 } else {


### PR DESCRIPTION
This commit fixes the implementation of the island architecture by creating a separate `StudyRoutes.js` file that contains the routes for the study mode, and using this file as the entry point for the study mode in `craco.config.js`. This ensures that the study mode has its own `BrowserRouter` and that the routing works correctly.

Changes:

*   Modified `index.js` to only render the `AppRoutes` component.
*   Modified `AppRoutes.js` to include the `BrowserRouter`.
*   Created a new `StudyRoutes.js` file that will contain the routes for the study mode.
*   Modified `craco.config.js` to use the new `StudyRoutes.js` file as the entry point for the study mode.