### PR TITLE
fix: Ensure useNavigate is used in context of a Router

### DIFF
--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 // import { usePlan } from './contexts/PlanContext'; // Commented out as PlanOverview is commented
 import { useAuth } from './contexts/AuthContext';
 import { useI18n } from './i18n/I18nContext';
@@ -24,9 +24,7 @@ const ProtectedRoute = ({ children }) => {
 
 function AppRoutes() {
     return (
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
+        <App />
     );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import AppRoutes from './AppRoutes';
 import { PlanProvider } from './contexts/PlanContext';
 import { AuthProvider } from './contexts/AuthContext';
@@ -16,17 +17,19 @@ if (rootElement) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <React.StrictMode>
-      <I18nProvider>
-        <LatinizationProvider>
-          <AuthProvider>
-            <UserProfileProvider>
-              <PlanProvider>
-                <AppRoutes />
-              </PlanProvider>
-            </UserProfileProvider>
-          </AuthProvider>
-        </LatinizationProvider>
-      </I18nProvider>
+      <BrowserRouter>
+        <I18nProvider>
+          <LatinizationProvider>
+            <AuthProvider>
+              <UserProfileProvider>
+                <PlanProvider>
+                  <AppRoutes />
+                </PlanProvider>
+              </UserProfileProvider>
+            </AuthProvider>
+          </LatinizationProvider>
+        </I18nProvider>
+      </BrowserRouter>
     </React.StrictMode>
   );
 } else {


### PR DESCRIPTION
This commit fixes the "useNavigate() may be used only in the context of a <Router> component" error by moving the `BrowserRouter` to `index.js` and wrapping the `App` component with it. This ensures that the `useNavigate` hook is called within the context of a `Router`.