### PR TITLE
feat: Add interactive scenarios to themed booster packs

### DIFF
--- a/public/data/booster_packs.json
+++ b/public/data/booster_packs.json
@@ -18,11 +18,33 @@
                 "scenes": [
                     {
                         "character": "Waiter",
-                        "line": "Bonjour ! Qu'est-ce que vous voulez ?"
+                        "line": "Bonjour ! Qu'est-ce que vous voulez ?",
+                        "choices": [
+                            { "text": "Je voudrais un café, s'il vous plaît.", "nextScene": 1 },
+                            { "text": "Un croissant, s'il vous plaît.", "nextScene": 2 }
+                        ]
                     },
                     {
-                        "character": "You",
-                        "line": "..."
+                        "character": "Waiter",
+                        "line": "Voilà un café. Autre chose ?",
+                        "choices": [
+                            { "text": "Non, merci. C'est tout.", "nextScene": 3 },
+                            { "text": "Oui, je voudrais aussi un croissant.", "nextScene": 2 }
+                        ]
+                    },
+                    {
+                        "character": "Waiter",
+                        "line": "Et un croissant. Voilà. Autre chose ?",
+                        "choices": [
+                            { "text": "Non, merci. L'addition, s'il vous plaît.", "nextScene": 3 }
+                        ]
+                    },
+                    {
+                        "character": "Waiter",
+                        "line": "Ça fait 4 euros.",
+                        "choices": [
+                            { "text": "Merci, au revoir !", "nextScene": 4 }
+                        ]
                     }
                 ]
             }
@@ -47,11 +69,34 @@
                 "scenes": [
                     {
                         "character": "Vendor",
-                        "line": "いらっしゃいませ！"
+                        "line": "いらっしゃいませ！",
+                        "choices": [
+                            { "text": "たこ焼きをください。", "nextScene": 1 },
+                            { "text": "お好み焼きをください。", "nextScene": 2 }
+                        ]
                     },
                     {
-                        "character": "You",
-                        "line": "..."
+                        "character": "Vendor",
+                        "line": "はい、たこ焼きですね。ソースはどうしますか？",
+                        "choices": [
+                            { "text": "普通のでお願いします。", "nextScene": 3 },
+                            { "text": "辛口でお願いします。", "nextScene": 3 }
+                        ]
+                    },
+                    {
+                        "character": "Vendor",
+                        "line": "はい、お好み焼きですね。マヨネーズはかけますか？",
+                        "choices": [
+                            { "text": "はい、お願いします。", "nextScene": 3 },
+                            { "text": "いいえ、結構です。", "nextScene": 3 }
+                        ]
+                    },
+                    {
+                        "character": "Vendor",
+                        "line": "はい、どうぞ。500円です。",
+                        "choices": [
+                            { "text": "ありがとうございます！", "nextScene": 4 }
+                        ]
                     }
                 ]
             }

--- a/src/components/Freestyle/BoosterPack.js
+++ b/src/components/Freestyle/BoosterPack.js
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
+import InteractiveScenario from './InteractiveScenario';
 import './BoosterPack.css';
 
 const BoosterPack = ({ pack }) => {
+    const [isScenarioVisible, setIsScenarioVisible] = useState(false);
+
     return (
         <div className="booster-pack">
             <h3>{pack.title}</h3>
             <p>{pack.description}</p>
-            <button>Start</button>
+            <button onClick={() => setIsScenarioVisible(true)}>Start Scenario</button>
+            {isScenarioVisible && (
+                <InteractiveScenario
+                    scenario={pack.content.scenario}
+                    onClose={() => setIsScenarioVisible(false)}
+                />
+            )}
         </div>
     );
 };

--- a/src/components/Freestyle/BoosterPack.test.js
+++ b/src/components/Freestyle/BoosterPack.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BoosterPack from './BoosterPack';
+
+const mockPack = {
+    "id": 1,
+    "title": "Cafe Hopping in Paris",
+    "description": "Learn how to order coffee and pastries in a Parisian cafe.",
+    "content": {
+        "scenario": {
+            "title": "Ordering at the Cafe",
+            "scenes": [
+                {
+                    "character": "Waiter",
+                    "line": "Bonjour ! Qu'est-ce que vous voulez ?",
+                    "choices": [
+                        { "text": "Je voudrais un café, s'il vous plaît.", "nextScene": 1 },
+                        { "text": "Un croissant, s'il vous plaît.", "nextScene": 2 }
+                    ]
+                }
+            ]
+        }
+    }
+};
+
+describe('BoosterPack', () => {
+    it('renders the component', () => {
+        render(<BoosterPack pack={mockPack} />);
+        expect(screen.getByText('Cafe Hopping in Paris')).toBeInTheDocument();
+    });
+
+    it('opens the interactive scenario when the button is clicked', () => {
+        render(<BoosterPack pack={mockPack} />);
+        const button = screen.getByText('Start Scenario');
+        fireEvent.click(button);
+        expect(screen.getByText('Ordering at the Cafe')).toBeInTheDocument();
+    });
+});

--- a/src/components/Freestyle/InteractiveScenario.css
+++ b/src/components/Freestyle/InteractiveScenario.css
@@ -1,0 +1,43 @@
+.interactive-scenario-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.interactive-scenario-content {
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+    width: 500px;
+    position: relative;
+}
+
+.close-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+}
+
+.scene {
+    margin-bottom: 20px;
+}
+
+.character {
+    font-weight: bold;
+}
+
+.choices {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}

--- a/src/components/Freestyle/InteractiveScenario.js
+++ b/src/components/Freestyle/InteractiveScenario.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import './InteractiveScenario.css';
+
+const InteractiveScenario = ({ scenario, onClose }) => {
+    const [currentScene, setCurrentScene] = useState(scenario.scenes[0]);
+
+    const handleChoice = (nextSceneIndex) => {
+        if (nextSceneIndex < scenario.scenes.length) {
+            setCurrentScene(scenario.scenes[nextSceneIndex]);
+        } else {
+            onClose();
+        }
+    };
+
+    return (
+        <div className="interactive-scenario-modal">
+            <div className="interactive-scenario-content">
+                <button onClick={onClose} className="close-button">&times;</button>
+                <h3>{scenario.title}</h3>
+                <div className="scene">
+                    <p className="character">{currentScene.character}</p>
+                    <p className="line">{currentScene.line}</p>
+                </div>
+                <div className="choices">
+                    {currentScene.choices.map((choice, index) => (
+                        <button key={index} onClick={() => handleChoice(choice.nextScene)}>
+                            {choice.text}
+                        </button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default InteractiveScenario;


### PR DESCRIPTION
This commit adds interactive scenarios to the themed booster packs feature.

The new feature allows you to practice your conversation skills in a low-pressure environment by choosing the correct response from a list of options.

The following changes were made:
- Created a new `InteractiveScenario` component.
- Updated the `BoosterPack` component to launch the interactive scenario.
- Updated the `booster_packs.json` data file to include more detailed scenarios.

The tests were not run due to a timeout issue.