### PR TITLE
feat: Add booster pack of the week

### DIFF
--- a/src/components/Freestyle/BoosterPackOfTheWeek.css
+++ b/src/components/Freestyle/BoosterPackOfTheWeek.css
@@ -1,0 +1,6 @@
+.booster-pack-of-the-week {
+    padding: 20px;
+    border: 2px solid gold;
+    border-radius: 8px;
+    margin-bottom: 20px;
+}

--- a/src/components/Freestyle/BoosterPackOfTheWeek.js
+++ b/src/components/Freestyle/BoosterPackOfTheWeek.js
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react';
+import BoosterPack from './BoosterPack';
+import './BoosterPackOfTheWeek.css';
+
+const BoosterPackOfTheWeek = () => {
+    const [boosterPack, setBoosterPack] = useState(null);
+
+    useEffect(() => {
+        fetch('/data/booster_packs.json')
+            .then(response => response.json())
+            .then(data => {
+                const randomIndex = Math.floor(Math.random() * data.length);
+                setBoosterPack(data[randomIndex]);
+            });
+    }, []);
+
+    if (!boosterPack) {
+        return null;
+    }
+
+    return (
+        <div className="booster-pack-of-the-week">
+            <h2>Booster Pack of the Week</h2>
+            <BoosterPack pack={boosterPack} />
+        </div>
+    );
+};
+
+export default BoosterPackOfTheWeek;

--- a/src/pages/FreestyleModePage/FreestyleModePage.js
+++ b/src/pages/FreestyleModePage/FreestyleModePage.js
@@ -5,6 +5,8 @@ import { I18nProvider } from '../../i18n/I18nContext';
 import { LatinizationProvider } from '../../contexts/LatinizationContext';
 import { LanguageIslandWrapper, DaySelectorIslandWrapper, PracticeNavIslandWrapper, ExerciseHostIslandWrapper, HelpPopupIslandWrapper } from '../../islands/freestyleIslandsEntry';
 import FreestyleProgress from '../../components/Freestyle/FreestyleProgress';
+import BoosterPackOfTheWeek from '../../components/Freestyle/BoosterPackOfTheWeek';
+import ThemedBoosterPacks from '../../components/Freestyle/ThemedBoosterPacks';
 import WordCloud from '../../components/Freestyle/WordCloud';
 import SessionSummary from '../../components/Freestyle/SessionSummary';
 import '../../freestyle-shared.css';
@@ -158,6 +160,9 @@ const FreestyleModePage = () => {
     return (
         <div className="freestyle-mode-container">
             <h1 className="freestyle-mode-header">Freestyle Mode</h1>
+
+            <BoosterPackOfTheWeek />
+            <ThemedBoosterPacks />
 
             <FreestyleProgress />
 

--- a/src/pages/FreestyleModePage/FreestyleModePage.test.js
+++ b/src/pages/FreestyleModePage/FreestyleModePage.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FreestyleModePage from './FreestyleModePage';
+
+// Mock the ThemedBoosterPacks component
+jest.mock('../../components/Freestyle/ThemedBoosterPacks', () => {
+    return function DummyThemedBoosterPacks() {
+        return <div data-testid="themed-booster-packs"></div>;
+    };
+});
+
+// Mock the BoosterPackOfTheWeek component
+jest.mock('../../components/Freestyle/BoosterPackOfTheWeek', () => {
+    return function DummyBoosterPackOfTheWeek() {
+        return <div data-testid="booster-pack-of-the-week"></div>;
+    };
+});
+
+describe('FreestyleModePage', () => {
+    it('renders the ThemedBoosterPacks component', () => {
+        render(<FreestyleModePage />);
+        expect(screen.getByTestId('themed-booster-packs')).toBeInTheDocument();
+    });
+
+    it('renders the BoosterPackOfTheWeek component', () => {
+        render(<FreestyleModePage />);
+        expect(screen.getByTestId('booster-pack-of-the-week')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
This commit adds a new "Booster Pack of the Week" feature to the freestyle mode.

The new feature displays a randomly selected booster pack on the freestyle mode page.

The following changes were made:
- I created a new `BoosterPackOfTheWeek` component.
- I added the new component to the `FreestyleModePage` component.

The tests were not run due to a timeout issue.