### PR TITLE
feat: Add mistake notebook

### DIFF
--- a/src/components/Freestyle/exercises/grammar/WordOrderExercise.js
+++ b/src/components/Freestyle/exercises/grammar/WordOrderExercise.js
@@ -5,6 +5,7 @@ import { processVerbData, generateGrammarExerciseSentence, setGrammarGeneratorTr
 import useLatinization from '../../../../hooks/useLatinization';
 import { shuffleArray } from '../../../../utils/arrayUtils';
 import { normalizeString } from '../../../../utils/stringUtils';
+import { logMistake } from '../../../../utils/mistakeLogger';
 import FeedbackDisplay from '../../FeedbackDisplay';
 import ExerciseControls from '../../ExerciseControls';
 import { useI18n } from '../../../../i18n/I18nContext';
@@ -112,6 +113,11 @@ const WordOrderExercise = ({ language, days, exerciseKey }) => {
       setIsCorrect(true);
     } else {
       setFeedback({ message: t('feedback.incorrectWordOrder', `Incorrect order. The correct sentence is: "${getLatinizedText(exerciseData.correctSentence, language)}"`, {correctSentence: getLatinizedText(exerciseData.correctSentence, language)}), type: 'incorrect' });
+      logMistake({
+        exercise: 'Word Order',
+        userAnswer: userAnswerSentence,
+        correctAnswer: correctAnswerSentence,
+      });
     }
   };
 

--- a/src/components/StudyMode/MistakeNotebook.css
+++ b/src/components/StudyMode/MistakeNotebook.css
@@ -1,0 +1,15 @@
+.mistake-notebook {
+    padding: 20px;
+}
+
+.mistake-notebook ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.mistake-notebook li {
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 20px;
+}

--- a/src/components/StudyMode/MistakeNotebook.js
+++ b/src/components/StudyMode/MistakeNotebook.js
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+import { getMistakes } from '../../utils/mistakeLogger';
+import './MistakeNotebook.css';
+
+const MistakeNotebook = () => {
+    const [mistakes, setMistakes] = useState([]);
+
+    useEffect(() => {
+        setMistakes(getMistakes());
+    }, []);
+
+    return (
+        <div className="mistake-notebook">
+            <h2>Mistake Notebook</h2>
+            {mistakes.length > 0 ? (
+                <ul>
+                    {mistakes.map((mistake, index) => (
+                        <li key={index}>
+                            <p><strong>Exercise:</strong> {mistake.exercise}</p>
+                            <p><strong>Your Answer:</strong> {mistake.userAnswer}</p>
+                            <p><strong>Correct Answer:</strong> {mistake.correctAnswer}</p>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p>No mistakes recorded yet. Keep practicing!</p>
+            )}
+        </div>
+    );
+};
+
+export default MistakeNotebook;

--- a/src/pages/StudyModePage/StudentDashboard.js
+++ b/src/pages/StudyModePage/StudentDashboard.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useI18n } from '../../i18n/I18nContext';
 import TransliterableText from '../../components/Common/TransliterableText';
+import MistakeNotebook from '../../components/StudyMode/MistakeNotebook';
 
 // Import the centralized displayComponentMap
 import { displayComponentMap } from '../../components/StudyMode/common/displayComponentMap';
@@ -13,6 +14,7 @@ import './StudentDashboard.css';
 
 const StudentDashboard = ({ lessonBlocks = [] }) => {
   const { t } = useI18n();
+  const [isMistakeNotebookVisible, setIsMistakeNotebookVisible] = useState(false);
   
   const handleNavigateBlock = (direction, currentIndex) => {
     let targetIndex;
@@ -46,8 +48,11 @@ const StudentDashboard = ({ lessonBlocks = [] }) => {
       <div className="lesson-header">
         {/* TODO: Display actual lesson name from syllabus if available */}
         <h2><TransliterableText text={t('studyMode.lessonTitlePlaceholder', 'Current Lesson')} /></h2>
+        <button onClick={() => setIsMistakeNotebookVisible(true)}>Mistake Notebook</button>
       </div>
       
+      {isMistakeNotebookVisible && <MistakeNotebook />}
+
       <div className="lesson-content-student-view">
         {lessonBlocks.map((block, index) => {
           // Syllabus uses 'block_type', displayComponentMap might use 'typePath' or will be updated.

--- a/src/pages/StudyModePage/StudentDashboard.test.js
+++ b/src/pages/StudyModePage/StudentDashboard.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import StudentDashboard from './StudentDashboard';
+
+// Mock the MistakeNotebook component
+jest.mock('../../components/StudyMode/MistakeNotebook', () => {
+    return function DummyMistakeNotebook() {
+        return <div data-testid="mistake-notebook"></div>;
+    };
+});
+
+describe('StudentDashboard', () => {
+    it('renders the Mistake Notebook button', () => {
+        render(<StudentDashboard />);
+        expect(screen.getByText('Mistake Notebook')).toBeInTheDocument();
+    });
+
+    it('shows the MistakeNotebook component when the button is clicked', () => {
+        render(<StudentDashboard />);
+        const button = screen.getByText('Mistake Notebook');
+        fireEvent.click(button);
+        expect(screen.getByTestId('mistake-notebook')).toBeInTheDocument();
+    });
+});

--- a/src/utils/mistakeLogger.js
+++ b/src/utils/mistakeLogger.js
@@ -1,0 +1,10 @@
+export const logMistake = (mistake) => {
+    const mistakes = getMistakes();
+    mistakes.push(mistake);
+    localStorage.setItem('mistakes', JSON.stringify(mistakes));
+};
+
+export const getMistakes = () => {
+    const mistakes = localStorage.getItem('mistakes');
+    return mistakes ? JSON.parse(mistakes) : [];
+};


### PR DESCRIPTION
This commit adds a new "Mistake Notebook" feature to the study mode.

The new feature allows you to review your mistakes and learn from them.

The following changes were made:
- Created a new `MistakeNotebook` component.
- Created a new `mistakeLogger` utility function.
- Updated the `WordOrderExercise` component to log mistakes.
- Added a "Mistake Notebook" button to the `StudentDashboard` component.

The tests were not run due to a timeout issue.