### PR TITLE
feat: Add shadowing exercise

### DIFF
--- a/src/components/Freestyle/ExerciseHost.js
+++ b/src/components/Freestyle/ExerciseHost.js
@@ -43,6 +43,7 @@ import InterestingFactExercise from './exercises/reading/InterestingFactExercise
 import SpeakingQuestionExercise from './exercises/speaking/SpeakingQuestionExercise';
 import MonologueExercise from './exercises/speaking/MonologueExercise';
 import RolePlayExercise from './exercises/speaking/RolePlayExercise';
+import ShadowingExercise from '../../StudyMode/ShadowingExercise';
 
 // Writing Exercise Components
 import WritingQuestionExercise from './exercises/writing/WritingQuestionExercise';
@@ -105,6 +106,7 @@ const exerciseMap = {
   'speaking_question_exercise': SpeakingQuestionExercise,
   'speaking_monologue_exercise': MonologueExercise,
   'speaking_role_play_exercise': RolePlayExercise,
+  'speaking_shadowing_exercise': ShadowingExercise,
 
   // Writing
   'writing_question_exercise': WritingQuestionExercise,

--- a/src/components/StudyMode/ShadowingExercise.css
+++ b/src/components/StudyMode/ShadowingExercise.css
@@ -1,0 +1,12 @@
+.shadowing-exercise {
+    padding: 20px;
+}
+
+.correct {
+    color: green;
+}
+
+.incorrect {
+    color: red;
+    text-decoration: line-through;
+}

--- a/src/components/StudyMode/ShadowingExercise.js
+++ b/src/components/StudyMode/ShadowingExercise.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
+import './ShadowingExercise.css';
+
+const ShadowingExercise = ({ audioSrc, transcript }) => {
+    const [isListening, setIsListening] = useState(false);
+    const [feedback, setFeedback] = useState([]);
+    const {
+        transcript: userTranscript,
+        listening,
+        resetTranscript,
+        browserSupportsSpeechRecognition
+    } = useSpeechRecognition();
+
+    const audio = new Audio(audioSrc);
+
+    const handleListen = () => {
+        if (listening) {
+            SpeechRecognition.stopListening();
+            setIsListening(false);
+        } else {
+            resetTranscript();
+            setFeedback([]);
+            SpeechRecognition.startListening({ continuous: true });
+            setIsListening(true);
+            audio.play();
+        }
+    };
+
+    const compareTranscripts = () => {
+        const originalWords = transcript.split(' ');
+        const userWords = userTranscript.split(' ');
+        const newFeedback = [];
+
+        originalWords.forEach((word, index) => {
+            if (userWords[index] === word) {
+                newFeedback.push({ word, isCorrect: true });
+            } else {
+                newFeedback.push({ word, isCorrect: false });
+            }
+        });
+        setFeedback(newFeedback);
+    };
+
+    useEffect(() => {
+        if (!listening && userTranscript) {
+            compareTranscripts();
+        }
+    }, [listening, userTranscript]);
+
+    if (!browserSupportsSpeechRecognition) {
+        return <span>Browser doesn't support speech recognition.</span>;
+    }
+
+    return (
+        <div className="shadowing-exercise">
+            <h2>Shadowing Exercise</h2>
+            <p>
+                <strong>Original Transcript:</strong>
+                {feedback.map((item, index) => (
+                    <span key={index} className={item.isCorrect ? 'correct' : 'incorrect'}>
+                        {item.word}{' '}
+                    </span>
+                ))}
+            </p>
+            <p><strong>Your Transcript:</strong> {userTranscript}</p>
+            <button onClick={handleListen}>
+                {listening ? 'Stop' : 'Start'}
+            </button>
+        </div>
+    );
+};
+
+export default ShadowingExercise;

--- a/src/components/StudyMode/ShadowingExercise.test.js
+++ b/src/components/StudyMode/ShadowingExercise.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ShadowingExercise from './ShadowingExercise';
+
+// Mock the react-speech-recognition library
+jest.mock('react-speech-recognition', () => ({
+    ...jest.requireActual('react-speech-recognition'),
+    useSpeechRecognition: () => ({
+        transcript: 'This is a test transcript',
+        listening: false,
+        resetTranscript: jest.fn(),
+        browserSupportsSpeechRecognition: true,
+    }),
+}));
+
+describe('ShadowingExercise', () => {
+    it('renders the component', () => {
+        render(<ShadowingExercise audioSrc="" transcript="This is a test transcript" />);
+        expect(screen.getByText('Shadowing Exercise')).toBeInTheDocument();
+    });
+
+    it('displays the original transcript', () => {
+        render(<ShadowingExercise audioSrc="" transcript="This is a test transcript" />);
+        expect(screen.getByText('This is a test transcript')).toBeInTheDocument();
+    });
+
+    it('displays the user transcript', () => {
+        render(<ShadowingExercise audioSrc="" transcript="This is a test transcript" />);
+        expect(screen.getByText('Your Transcript:')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
This commit adds a new "Shadowing" with AI Feedback feature to the study mode.

The new feature allows you to practice your pronunciation and fluency by shadowing a native speaker.

The following changes were made:
- Created a new `ShadowingExercise` component.
- Integrated the `react-speech-recognition` library to get a transcript of your recording.
- Compared your transcript with the original transcript and provided feedback.
- Added the new exercise to the `ExerciseHost` component.

I was unable to run the tests due to a timeout issue.