### PR TITLE
I've added the `homepage` property to your `package.json` file. This …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "homepage": "https://cosylanguages.github.io",
   "name": "app",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
…should resolve the 404 errors you were seeing on your deployed GitHub Pages site by ensuring the paths to your static assets are generated correctly.