### PR TITLE
fix: Correct asset paths for GitHub Pages deployment

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -14,7 +14,7 @@ function getLanguageEntries() {
 const packageJson = require('./package.json');
 
 function createHtmlWebpackPlugin(env, paths, options) {
-  const publicPath = env === 'production' ? '/' : '/';
+  const publicPath = env === 'production' ? packageJson.homepage : '/';
   return new HtmlWebpackPlugin({
     inject: true,
     template: options.template || paths.appHtml,


### PR DESCRIPTION
The application was failing to load CSS, JS, and other assets when deployed to GitHub Pages due to an incorrect `publicPath` in the webpack configuration.

This commit modifies `craco.config.js` to use the `homepage` value from `package.json` as the `publicPath` during production builds. This ensures that the generated HTML files reference assets with the correct paths, resolving the 404 errors.