### PR TITLE
feat: Revamp landing page

### DIFF
--- a/src/components/LanguageSelector/CosyLanguageSelector.js
+++ b/src/components/LanguageSelector/CosyLanguageSelector.js
@@ -8,26 +8,26 @@ import './CosyLanguageSelector.css';
 
 // A map of language keys to their corresponding logo images.
 const logos = {
-  COSYarmenian: '/assets/icons/cosylanguages_logos/cosyarmenian.png',
-  COSYbashkir: '/assets/icons/cosylanguages_logos/cosybachkir.png',
-  COSYbreton: '/assets/icons/cosylanguages_logos/cosybreton.png',
-  COSYenglish: '/assets/icons/cosylanguages_logos/cosyenglish.png',
-  COSYfrench: '/assets/icons/cosylanguages_logos/cosyfrench.png',
-  COSYgeorgian: '/assets/icons/cosylanguages_logos/cosygeorgian.png',
-  COSYgerman: '/assets/icons/cosylanguages_logos/cosygerman.png',
-  COSYgreek: '/assets/icons/cosylanguages_logos/cosygreek.png',
-  COSYitalian: '/assets/icons/cosylanguages_logos/cosyitalian.png',
-  COSYportuguese: '/assets/icons/cosylanguages_logos/cosyportuguese.png',
-  COSYrussian: '/assets/icons/cosylanguages_logos/cosyrussian.png',
-  COSYspanish: '/assets/icons/cosylanguages_logos/cosyspanish.png',
-  COSYtatar: '/assets/icons/cosylanguages_logos/cosytatar.png',
+  COSYarmenian: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyarmenian.png',
+  COSYbashkir: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosybachkir.png',
+  COSYbreton: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosybreton.png',
+  COSYenglish: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyenglish.png',
+  COSYfrench: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyfrench.png',
+  COSYgeorgian: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosygeorgian.png',
+  COSYgerman: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosygerman.png',
+  COSYgreek: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosygreek.png',
+  COSYitalian: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyitalian.png',
+  COSYportuguese: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyportuguese.png',
+  COSYrussian: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyrussian.png',
+  COSYspanish: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosyspanish.png',
+  COSYtatar: '/COSYlanguagesproject/assets/icons/cosylanguages_logos/cosytatar.png',
 };
 
 // Map des drapeaux pour chaque langue (ajouter selon les fichiers disponibles)
 const flags = {
-  COSYbashkir: '/assets/flags/Flag_of_Bashkortostan.png',
-  COSYbreton: '/assets/flags/Flag_of_Brittany.png',
-  COSYtatar: '/assets/flags/Flag_of_Tatarstan.png',
+  COSYbashkir: '/COSYlanguagesproject/assets/flags/Flag_of_Bashkortostan.png',
+  COSYbreton: '/COSYlanguagesproject/assets/flags/Flag_of_Brittany.png',
+  COSYtatar: '/COSYlanguagesproject/assets/flags/Flag_of_Tatarstan.png',
 };
 
 /**

--- a/src/pages/LandingPage/LandingPage.css
+++ b/src/pages/LandingPage/LandingPage.css
@@ -4,12 +4,46 @@
     text-align: center;
 }
 
+.calculator-wrapper {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.calculator-toggle {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  font-size: 2rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: transform 0.3s ease;
+}
+
+.calculator-toggle:hover {
+  transform: scale(1.1);
+}
+
 .calculator-container {
-    margin-top: 40px;
-    border: 1px solid #eee;
-    border-radius: 10px;
-    padding: 20px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+  position: absolute;
+  bottom: 80px;
+  right: 0;
+  width: 300px;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.2);
+  padding: 20px;
+  transform: scale(0);
+  transform-origin: bottom right;
+  transition: transform 0.3s ease;
+}
+
+.calculator-wrapper.open .calculator-container {
+  transform: scale(1);
 }
 /* Animation du message d'encouragement */
 .encouragement-message {

--- a/src/pages/LandingPage/LandingPage.js
+++ b/src/pages/LandingPage/LandingPage.js
@@ -1,5 +1,5 @@
 // Import necessary libraries and components.
-import React, { useRef } from 'react';
+import React, { useState, useRef } from 'react';
 // Import the Link component from react-router-dom for navigation.
 import { Link } from 'react-router-dom';
 // Import the CSS for this component.
@@ -14,6 +14,7 @@ import Calculator from '../../components/Calculator/Calculator';
  * @returns {JSX.Element} The LandingPage component.
  */
 function LandingPage() {
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
   // Ref pour la zone d'accueil (pour positionner les confettis)
   const landingContentRef = useRef(null);
 
@@ -42,10 +43,6 @@ function LandingPage() {
         <p>Apprenez, jouez et progressez chaque jour dans une ambiance fun et motivante.</p>
         {/* Logo animé */}
         <img src="/COSYlanguagesproject/cosylanguages.png" alt="Cosy Languages Logo" className="logo animated-logo" />
-        {/* Bouton Quiz du jour avec effet confettis */}
-        <div style={{ margin: '30px 0' }}>
-          <Link to="/study-tools?quiz=day" className="quiz-button" onClick={launchConfetti}>Quiz du jour 🎲</Link>
-        </div>
         {/* Boutons principaux */}
         <div className="landing-buttons">
           <Link to="/freestyle" className="landing-button">Freestyle</Link>
@@ -58,8 +55,13 @@ function LandingPage() {
           <h2 style={{marginTop: '40px', fontSize: '1.5em', color: '#007bff'}}>Langues disponibles</h2>
           <LanguageSelector />
         </div>
-        <div className="calculator-container">
-          <Calculator />
+        <div className={`calculator-wrapper ${isCalculatorOpen ? 'open' : ''}`}>
+          <button onClick={() => setIsCalculatorOpen(!isCalculatorOpen)} className="calculator-toggle">
+            🧮
+          </button>
+          <div className="calculator-container">
+            <Calculator />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit revamps the landing page with the following changes:

- The calculator is now hidden behind a button with a calculator emoji. Clicking the button toggles the calculator's visibility with a cozy animation.
- The language selector now correctly displays the language logos and flags.
- The "Quiz du jour" button has been removed.