### PR TITLE
Fix widespread errors in test suite

### DIFF
--- a/src/components/Freestyle/exercises/common/FillInTheBlanksPracticeHost.test.js
+++ b/src/components/Freestyle/exercises/common/FillInTheBlanksPracticeHost.test.js
@@ -5,14 +5,18 @@ import FillInTheBlanksPracticeHost from './FillInTheBlanksPracticeHost';
 import * as exerciseDataService from '../../../../utils/exerciseDataService';
 
 jest.mock('../../../../utils/exerciseDataService');
-jest.mock('./FillInTheBlanksExercise', () => ({ exerciseData, onCorrect, onIncorrect, onAttempt }) => (
-  <div data-testid="fill-in-blanks-exercise-mock">
-    <p>Exercise ID: {exerciseData?.id}</p>
-    <button onClick={onCorrect}>CorrectBTN</button>
-    <button onClick={onIncorrect}>IncorrectBTN</button>
-    <button onClick={onAttempt}>AttemptBTN</button>
-  </div>
-));
+jest.mock('./FillInTheBlanksExercise', () => {
+    return function DummyFillInTheBlanksExercise({ exerciseData, onCorrect, onIncorrect, onAttempt }) {
+        return (
+            <div data-testid="fill-in-blanks-exercise-mock">
+                <p>Exercise ID: {exerciseData?.id}</p>
+                <button onClick={onCorrect}>CorrectBTN</button>
+                <button onClick={onIncorrect}>IncorrectBTN</button>
+                <button onClick={onAttempt}>AttemptBTN</button>
+            </div>
+        );
+    };
+});
 
 const mockExercises = [
   { id: 'fitb1', sentenceParts: ["Part 1 ", null], answers: ["Ans1"] },

--- a/src/pages/MyStudySetsPage/MyStudySetsPage.test.js
+++ b/src/pages/MyStudySetsPage/MyStudySetsPage.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '../../testUtils';
 import '@testing-library/jest-dom';
 import MyStudySetsPage from './MyStudySetsPage';
-import { I18nProvider } from '../../i18n/I18nContext';
-import { AuthProvider } from '../../contexts/AuthContext';
-import { StudySetProvider } from '../../contexts/StudySetContext';
 import { mockNavigateForTest, mockUseLocationForTest, mockUseParamsForTest } from 'react-router-dom';
 
 // --- Mock studySetService at the top level ---
@@ -53,24 +50,10 @@ const renderPage = async (pathname = '/my-sets', params = {}) => {
   mockUseLocationForTest.mockReturnValue({ pathname, search: '', hash: '', state: null, key: 'testKey' });
   mockUseParamsForTest.mockReturnValue(params);
 
-  const authContextValue = {
-    isAuthenticated: true, currentUser: { uid: 'test-user', role: 'student' }, loadingAuth: false,
-    login: jest.fn(), logout: jest.fn(), signup: jest.fn(), updateUserRoleInDb: jest.fn(),
-    getToken: jest.fn().mockResolvedValue('fake-token'),
-  };
-
   let utils;
   // Use act for renders that trigger useEffect data fetching
   await act(async () => {
-    utils = render(
-        <I18nProvider i18n={{ t: mockT, language: 'COSYenglish', currentLangKey: 'COSYenglish' }}>
-          <AuthProvider value={authContextValue}>
-            <StudySetProvider>
-              <MyStudySetsPage />
-            </StudySetProvider>
-          </AuthProvider>
-        </I18nProvider>
-    );
+    utils = render(<MyStudySetsPage />);
   });
   return utils;
 };


### PR DESCRIPTION
This commit addresses numerous issues in the test suite that were causing widespread failures. The root causes were varied and included incorrect test logic, incorrect mocks for child components, and tests not using the centralized `testUtils.js` for rendering.

The following changes were made:

- **Standardized on `testUtils.js`:** A number of component and page test files were updated to use the custom `render` function from `testUtils.js`. This ensures that all components are rendered within the necessary provider context.

- **Corrected Test Logic:** The tests for the `Login` component were completely rewritten to match the actual component implementation.

- **Fixed Incorrect Mocks:** An incorrect mock for the `FillInTheBlanksExercise` component was fixed in `FillInTheBlanksPracticeHost.test.js`.

- **Fixed Import Paths:** Corrected an invalid relative import path for `testUtils.js` in `FreestyleModePage.test.js`.

Due to persistent timeouts in the testing environment, it was not possible to run the test suite to verify these changes. The implemented solution directly addresses the error patterns you described and which I observed in the code.