### PR TITLE
Refactor the freestyle page to improve user experience and code quality.

### DIFF
--- a/src/components/Freestyle/DaySelectorFreestyle.css
+++ b/src/components/Freestyle/DaySelectorFreestyle.css
@@ -119,3 +119,8 @@
   background-color: var(--color-surface-light, #e6f2ff); /* Very light blue background */
   border-radius: var(--border-radius-sm, 4px);
 }
+
+.day-select-dropdown option.selected {
+  background-color: var(--primary-color);
+  color: var(--text-color-light);
+}

--- a/src/components/Freestyle/DaySelectorFreestyle.js
+++ b/src/components/Freestyle/DaySelectorFreestyle.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { useI18n } from '../../i18n/I18nContext';
 import { useDaySelection } from '../../hooks/useDaySelection';
+import { useFreestyle } from '../../contexts/FreestyleContext';
 import './DaySelectorFreestyle.css';
 
 /**
@@ -11,6 +12,7 @@ import './DaySelectorFreestyle.css';
  * @returns {JSX.Element} The DaySelectorFreestyle component.
  */
 const DaySelectorFreestyle = ({ language }) => {
+  const { selectedDays } = useFreestyle();
   const {
     internalSingleDay,
     setInternalSingleDay,
@@ -75,7 +77,7 @@ const DaySelectorFreestyle = ({ language }) => {
           >
             <option value="">{t('daySelector.selectDay', 'Select Day')}</option>
             {daysOptions.map((day) => (
-              <option key={day} value={day}>
+              <option key={day} value={day} className={selectedDays.includes(day) ? 'selected' : ''}>
                 {day}
               </option>
             ))}
@@ -96,7 +98,7 @@ const DaySelectorFreestyle = ({ language }) => {
             <select id="freestyle-day-from" value={internalDayFrom} onChange={(e) => setInternalDayFrom(e.target.value)} className="day-select-dropdown">
               <option value="">{t('daySelector.selectStartDay', 'Start')}</option>
               {daysOptions.map((day) => (
-                <option key={`from-${day}`} value={day}>{day}</option>
+                <option key={`from-${day}`} value={day} className={selectedDays.includes(day) ? 'selected' : ''}>{day}</option>
               ))}
             </select>
           </div>
@@ -105,7 +107,7 @@ const DaySelectorFreestyle = ({ language }) => {
             <select id="freestyle-day-to" value={internalDayTo} onChange={(e) => setInternalDayTo(e.target.value)} className="day-select-dropdown">
               <option value="">{t('daySelector.selectEndDay', 'End')}</option>
               {daysOptions.map((day) => (
-                <option key={`to-${day}`} value={day}>{day}</option>
+                <option key={`to-${day}`} value={day} className={selectedDays.includes(day) ? 'selected' : ''}>{day}</option>
               ))}
             </select>
           </div>

--- a/src/components/Freestyle/PracticeCategoryNav.js
+++ b/src/components/Freestyle/PracticeCategoryNav.js
@@ -34,7 +34,7 @@ const PracticeCategoryNav = ({ language, days }) => {
           <button
             key={categoryKey}
             onClick={() => handleCategorySelect(categoryKey)}
-            className="practice-category-btn"
+            className={`practice-category-btn ${selectedExercise?.exercise === categoryKey ? 'active' : ''}`}
           >
             {t(categoryDisplayInfo[categoryKey].translationKey, categoryDisplayInfo[categoryKey].defaultLabel)}
           </button>

--- a/src/components/Freestyle/SessionSummary.js
+++ b/src/components/Freestyle/SessionSummary.js
@@ -4,10 +4,8 @@ import './SessionSummary.css';
 const SessionSummary = ({ summary }) => {
   return (
     <div className="session-summary">
-      <h3>Session Summary</h3>
-      <p>Time spent: {summary.timeSpent}</p>
-      <p>Words learned: {summary.wordsLearned}</p>
-      <p>XP gained: {summary.xpGained}</p>
+      <h3>Booster Pack Description</h3>
+      <p>{summary.description}</p>
     </div>
   );
 };

--- a/src/components/Freestyle/WordCloud.js
+++ b/src/components/Freestyle/WordCloud.js
@@ -5,6 +5,7 @@ const WordCloud = ({ words }) => {
   return (
     <div className="word-cloud">
       <h3>Words Discovered</h3>
+      <p>This is a visual representation of the words you will encounter in this booster pack.</p>
       <div className="cloud">
         {words.map((word, index) => (
           <span key={index} style={{ fontSize: `${word.size}em` }}>

--- a/src/hooks/useBoosterPacks.js
+++ b/src/hooks/useBoosterPacks.js
@@ -3,12 +3,27 @@ import { useState, useEffect } from 'react';
 export const useBoosterPacks = () => {
   const [boosterPacks, setBoosterPacks] = useState([]);
   const [userBoosterPacks, setUserBoosterPacks] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch('/data/booster_packs.json')
-      .then(response => response.json())
+    setLoading(true);
+    setError(null);
+    fetch(`${process.env.PUBLIC_URL}/data/booster_packs.json`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Failed to fetch booster packs');
+        }
+        return response.json();
+      })
       .then(data => {
         setBoosterPacks(data);
+      })
+      .catch(error => {
+        setError(error.message);
+      })
+      .finally(() => {
+        setLoading(false);
       });
   }, []);
 
@@ -23,5 +38,5 @@ export const useBoosterPacks = () => {
     localStorage.setItem('userBoosterPacks', JSON.stringify(newUserPacks));
   };
 
-  return { boosterPacks, userBoosterPacks, addUserBoosterPack };
+  return { boosterPacks, userBoosterPacks, addUserBoosterPack, loading, error };
 };

--- a/src/pages/FreestyleModePage/FreestyleModePage.css
+++ b/src/pages/FreestyleModePage/FreestyleModePage.css
@@ -9,6 +9,22 @@
     color: #333;
 }
 
+.welcome-message {
+    text-align: center;
+    padding: 40px;
+    background-color: #f8f9fa;
+    border-radius: 8px;
+    margin-bottom: 20px;
+}
+
+.practice-section {
+    margin-bottom: 40px;
+    padding: 20px;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    background-color: #ffffff;
+}
+
 .island-placeholder {
     background-color: #ffffff;
     border-radius: 12px;

--- a/src/pages/FreestyleModePage/FreestyleModePage.js
+++ b/src/pages/FreestyleModePage/FreestyleModePage.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import LanguageHeader from '../../components/Common/LanguageHeader';
 // Import the useFreestyle hook to access the freestyle mode context.
 import { useFreestyle } from '../../contexts/FreestyleContext';
+import { useBoosterPacks } from '../../hooks/useBoosterPacks';
 // Import the components that make up the freestyle mode page.
 import DaySelectorFreestyle from '../../components/Freestyle/DaySelectorFreestyle';
 import PracticeCategoryNav from '../../components/Freestyle/PracticeCategoryNav';
@@ -25,20 +26,11 @@ import './FreestyleModePage.css';
 const FreestyleModePage = () => {
   // Get state from the freestyle context.
   const { selectedLanguage, selectedDays, selectedExercise } = useFreestyle();
+  const { boosterPacks } = useBoosterPacks();
   // State for booster packs, selected pack, words for the word cloud, and session summary.
-  const [boosterPacks, setBoosterPacks] = useState([]);
   const [selectedPack, setSelectedPack] = useState(null);
   const [words, setWords] = useState([]);
   const [summary, setSummary] = useState(null);
-
-  // Fetch the booster packs data when the component mounts.
-  useEffect(() => {
-    fetch('/data/booster_packs.json')
-      .then(response => response.json())
-      .then(data => {
-        setBoosterPacks(data);
-      });
-  }, []);
 
   // When a booster pack is selected, extract the words for the word cloud and set the summary.
   useEffect(() => {
@@ -58,33 +50,44 @@ const FreestyleModePage = () => {
   return (
     <div className="freestyle-mode-container">
       <h1 className="freestyle-mode-header">Freestyle Mode</h1>
-      {/* Affichage du logo et du drapeau de la langue sélectionnée */}
       {selectedLanguage && <LanguageHeader selectedLanguage={selectedLanguage} />}
-      {/* Display the booster packs and the user's progress. */}
-      <BoosterPacks boosterPacks={boosterPacks} onSelect={handlePackSelect} />
-      <FreestyleProgress />
-      {/* Container for the main freestyle mode controls. */}
-      <div className="freestyle-controls-container">
-        {/* Only show the day selector if a language is selected. */}
-        {selectedLanguage && <DaySelectorFreestyle language={selectedLanguage} />}
-        {/* Only show the practice category navigation if a language and days are selected. */}
-        {selectedLanguage && selectedDays.length > 0 && (
-          <PracticeCategoryNav language={selectedLanguage} days={selectedDays} />
-        )}
-      </div>
-      {/* If an exercise is selected, render the exercise host. */}
-      {selectedExercise && (
-        <ExerciseHost
-          language={selectedLanguage}
-          days={selectedDays}
-          subPracticeType={selectedExercise.exercise}
-        />
+
+      {!selectedLanguage ? (
+        <div className="welcome-message">
+          <h2>Welcome to Freestyle Mode!</h2>
+          <p>Please select a language from the header to get started.</p>
+        </div>
+      ) : (
+        <>
+          <div className="practice-section">
+            <h2>Practice with a Booster Pack</h2>
+            <p>Select a booster pack to get a curated set of vocabulary and exercises.</p>
+            <BoosterPacks boosterPacks={boosterPacks} onSelect={handlePackSelect} />
+            {selectedPack && <WordCloud words={words} />}
+            {summary && <SessionSummary summary={summary} />}
+          </div>
+
+          <div className="practice-section">
+            <h2>Custom Practice</h2>
+            <p>Create your own practice session by selecting a day and a category.</p>
+            <div className="freestyle-controls-container">
+              <DaySelectorFreestyle language={selectedLanguage} />
+              {selectedDays.length > 0 && (
+                <PracticeCategoryNav language={selectedLanguage} days={selectedDays} />
+              )}
+            </div>
+            {selectedExercise && (
+              <ExerciseHost
+                language={selectedLanguage}
+                days={selectedDays}
+                subPracticeType={selectedExercise.exercise}
+              />
+            )}
+          </div>
+        </>
       )}
-      {/* If a pack is selected, show the word cloud. */}
-      {selectedPack && <WordCloud words={words} />}
-      {/* If there is a summary, show the session summary. */}
-      {summary && <SessionSummary summary={summary} />}
-      {/* The help popup island component. */}
+
+      <FreestyleProgress />
       <HelpPopupIsland />
     </div>
   );


### PR DESCRIPTION
This commit addresses several issues with the freestyle page:

- **Refactors `FreestyleModePage.js`:** The component is now more user-friendly, with a welcome message and two distinct sections for "Booster Packs" and "Custom Practice".
- **Improves `useBoosterPacks` hook:** The hook now uses `process.env.PUBLIC_URL` for the fetch URL and includes error handling.
- **Adds visual feedback:** The `DaySelectorFreestyle` and `PracticeCategoryNav` components now highlight your selections.
- **Clarifies `WordCloud` and `SessionSummary`:** The purpose of these components is now explained with a title and a short description.