### PR TITLE
fix: Full SPA conversion and configuration for GitHub Pages

### DIFF
--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: '/api', // This will be proxied to the backend server in development
+  // Use an environment variable for the API base URL in production,
+  // and fall back to the proxy for development.
+  baseURL: process.env.REACT_APP_API_URL || '/api',
 });
 
 apiClient.interceptors.request.use((config) => {

--- a/src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js
+++ b/src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import IrregularVerbLevelSelector from './IrregularVerbLevelSelector';
 import useVerbs from '../../../hooks/useVerbs.js';
 import IrregularVerbQuiz from '../exercises/grammar/IrregularVerbQuiz';
@@ -80,7 +80,7 @@ const IrregularVerbsPractice = () => {
                 <button onClick={() => setExerciseType('quiz')} className={exerciseType === 'quiz' ? 'selected' : ''}>Quiz</button>
                 <button onClick={() => setExerciseType('fill-letters')} className={exerciseType === 'fill-letters' ? 'selected' : ''}>Fill Letters</button>
                 <button onClick={() => setExerciseType('fill-blanks')} className={exerciseType === 'fill-blanks' ? 'selected' : ''}>Fill Blanks</button>
-                <a href="/" className="study-mode-button">Study Mode</a>
+                <Link to="/" className="study-mode-button">Study Mode</Link>
             </div>
             <div className="category-selector">
                 {getCategories().map(cat => (


### PR DESCRIPTION
This commit resolves multiple issues preventing the application from functioning correctly when deployed to GitHub Pages. The application has been refactored into a proper Single-Page Application (SPA) and configured for a production environment.

Key changes:
- **SPA Conversion:** Refactored the build process by simplifying `craco.config.js` to produce a single `index.html`. All routing is now handled by `react-router-dom`. Obsolete multi-page artifacts and code (`freestyle.html`, `StudyRoutes.js`, etc.) have been removed.

- **API Configuration:** The API client (`src/api/apiClient.js`) is now configurable via the `REACT_APP_API_URL` environment variable. This is critical for the deployed application to connect to the correct backend, as the development proxy is not available in production.

- **Service Worker:** The service worker (`public/sw.js`) has been updated to use relative paths for caching and to remove references to deleted HTML files. This ensures that the application can be cached correctly for offline use.

- **Asset Paths:** Corrected a hardcoded link in the `IrregularVerbsPractice` component, replacing an `<a>` tag with a `react-router-dom` `<Link>` to ensure correct in-app navigation.

- **GitHub Pages Routing:** The `404.html` redirect script has been corrected to properly handle deep links for the SPA, ensuring users don't land on a 404 page when navigating directly to a route.