### PR TITLE
feat: Enhance community page and user profile

### DIFF
--- a/src/components/Community/SpeakingClubPost.js
+++ b/src/components/Community/SpeakingClubPost.js
@@ -10,9 +10,9 @@ import './SpeakingClubPost.css';
 const SpeakingClubPost = ({ event }) => {
   const { t } = useI18n();
   const { currentUser } = useAuth();
-  const [playing, setPlaying] = useState(true);
-  const [muted, setMuted] = useState(true);
-  const [loop, setLoop] = useState(true);
+  const [playing] = useState(true);
+  const [muted] = useState(true);
+  const [loop] = useState(true);
   const [newComment, setNewComment] = useState('');
   const [comments, setComments] = useState(event.comments || []);
 


### PR DESCRIPTION
This commit introduces several new features and improvements to the community and user profile sections of the application.

The community page has been refocused into a blogger-style feed of events, primarily for speaking clubs. This includes:
- A clear separation between current and past events, providing an archive of previous topics.
- The ability for you to comment on event posts.

The user profile has been enhanced with a vocabulary-building feature:
- You can now add vocabulary words from speaking club posts to your personal study sets.
- A "My Study Sets" tab has been added to the profile page, allowing you to manage your vocabulary lists.
- If you don't have a study set, a default "My Dictionary" is created for you when you first add a word.

The backend has been updated to support these features:
- The study sets API now uses MongoDB for persistence, replacing the previous mock data implementation.
- A mock authentication middleware has been added to simulate a logged-in user, enabling user-specific data to be saved.
- The events API now populates author details in comments.

fix: Fix linting errors in SpeakingClubPost component
- Removed unused variables to allow the build to pass.