### PR TITLE
fix: Disable service worker to prevent caching issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,4 +86,4 @@ if (rootElement) {
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://cra.link/PWA
-serviceWorkerRegistration.register();
+serviceWorkerRegistration.unregister();


### PR DESCRIPTION
The service worker was causing the website to not update for you because it was caching old assets. This change disables the service worker by calling unregister() instead of register(), ensuring that you always receive the latest version of the application.