### PR TITLE
Fix CI to run backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
 
-  test:
+  frontend-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,3 +30,19 @@ jobs:
           node-version: '16.x'
       - run: npm ci
       - run: npm test -- --watchAll=false
+
+  backend-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: ./backend
+      - name: Run backend tests
+        run: npm test
+        working-directory: ./backend


### PR DESCRIPTION
The CI was only running the frontend tests. This change adds a new job to the CI pipeline to install dependencies and run tests for the backend.

The existing 'test' job was also renamed to 'frontend-test' for clarity.