### PR TITLE
This commit fixes a build error in the LessonSectionsPanel component.

### DIFF
--- a/src/components/StudyMode/LessonSectionsPanel.js
+++ b/src/components/StudyMode/LessonSectionsPanel.js
@@ -24,6 +24,7 @@ const LessonSectionsPanel = ({
   selectedSectionId,
   currentLangKey,
   isStudentMode = false,
+  selectedDayId,
 }) => {
   const { t, language } = useI18n();
   const { currentUser } = useAuth();


### PR DESCRIPTION
The error was caused by the `selectedDayId` variable being used without being defined in the component's props.

This commit adds `selectedDayId` to the component's props to fix the error.