### PR TITLE
feat: Create and seed Speaking Club sessions

### DIFF
--- a/src/components/SpeakingClub.js
+++ b/src/components/SpeakingClub.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import specializedComponents from './SpeakingClub/Specialized';
 
 import './SpeakingClub.css';
 
@@ -142,8 +143,6 @@ const ClosingSection = ({ closing }) => {
   );
 };
 
-
-import specializedComponents from './SpeakingClub/Specialized';
 
 // --- Main SpeakingClub Component ---
 


### PR DESCRIPTION
This commit introduces the content for five new Speaking Club sessions, based on the architecture document.

- Created detailed JSON data for five specialized club types:
  - Keeping Up With Science
  - Let's Celebrate
  - The Greatest Quotes
  - Mind Matters
  - I Couldn't Help But Wonder
- Added a new seeding script (`backend/seed_new_clubs.js`) to populate the database with this new content.
- Installed and configured a MongoDB server in the environment to allow the seeding script and application to run.
- Updated the Event model schema in `backend/models/event.model.js` to support a wider variety of question types, making it more flexible for future content.

Additionally, a significant effort was made to fix the existing broken test suite:
- Fixed tests in `backend/events.test.js` that were failing due to incorrect assumptions about the API response and missing required fields.
- Fixed tests in `backend/studySets.test.js` that were failing due to missing authentication middleware and incorrect assertions.
- Attempted to fix tests in `backend/posts.test.js`, but one test continues to fail with a duplicate key error. The root cause of this final failure is still unknown.

Finally, a linting error in `src/components/SpeakingClub.js` was fixed.