### PR TITLE
fix: Fix data loading error in the Conjugation Tool

### DIFF
--- a/src/hooks/useVerbs.js
+++ b/src/hooks/useVerbs.js
@@ -15,9 +15,14 @@ const useVerbs = (levels, lang) => {
         const fetchVerbs = async () => {
             try {
                 console.log('Fetching verbs for lang:', lang);
-                const response = await fetch(`/data/grammar/verbs/verbs_${lang}.json`);
+                const response = await fetch(`/data/grammar/verbs/grammar_verbs_${lang}.json`);
                 console.log('Fetch response:', response);
                 if (!response.ok) {
+                    if (response.status === 404) {
+                        console.warn(`No verb data found for language: ${lang}`);
+                        setVerbs([]);
+                        return;
+                    }
                     throw new Error('Failed to fetch verbs');
                 }
                 const allVerbsData = await response.json();


### PR DESCRIPTION
This commit fixes a bug in the `useVerbs.js` hook that was causing a 404 Not Found error when trying to fetch verb data for certain languages.

The key changes include:
- Correcting the file path construction in `useVerbs.js` to match the actual data file names (`grammar_verbs_{lang}.json`).
- Improving the error handling in the hook to gracefully handle cases where a verb data file for a language does not exist. It now returns an empty array instead of throwing an error.