### PR TITLE
refactor(verbs): Integrate conjugation files into irregular verbs tool

### DIFF
--- a/src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js
+++ b/src/components/Freestyle/IrregularVerbs/IrregularVerbsPractice.js
@@ -101,7 +101,7 @@ const IrregularVerbsPractice = () => {
                 {renderExercise()}
                 {showDefinition && currentVerb && (
                     <div className="verb-definition-popup">
-                        <p><strong>Translation:</strong> {currentVerb.translation}</p>
+                        <p><strong>Translation:</strong> {currentVerb.translation_en}</p>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
- I refactored the `useVerbs` hook to fetch data from the `conjugations_*.json` files instead of the incorrect `grammar_verbs_*.json` files.
- I used the existing `conjugationDataService` to handle data fetching.
- I fixed the level-based filtering logic in the `useVerbs` hook.
- I updated the `IrregularVerbsPractice` component to correctly display the verb translation from the new data source.

This resolves the issue where the irregular verbs feature was not loading any data and was functionally broken.