### PR TITLE
fix(community): Make events route public

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -21,7 +21,7 @@ app.use('/api/progress', authMiddleware, progressRouter);
 app.use('/api/freestyle-progress', authMiddleware, freestyleProgressRouter);
 app.use('/api/booster-packs', boosterPacksRouter);
 app.use('/api/posts', authMiddleware, postsRouter);
-app.use('/api/events', authMiddleware, eventsRouter);
+app.use('/api/events', eventsRouter);
 app.use('/api/clubs', clubsRouter);
 app.use('/api/users', authMiddleware, usersRouter);
 


### PR DESCRIPTION
The events on the community page were not visible because the `/api/events` endpoint was protected by authentication middleware, while the frontend was trying to access it without authentication. This change removes the middleware, making the route public and allowing events to be fetched and displayed correctly.