### PR TITLE
fix(community): Add missing getClubs function

### DIFF
--- a/src/api/community.js
+++ b/src/api/community.js
@@ -47,6 +47,11 @@ export const getUsers = async () => {
   return response.data;
 };
 
+export const getClubs = async () => {
+  const response = await apiClient.get('/clubs');
+  return response.data;
+};
+
 export const createClub = async (clubData) => {
   const response = await apiClient.post('/clubs', clubData);
   return response.data;


### PR DESCRIPTION
The previous commit was missing the `getClubs` function in `src/api/community.js`, which caused the build to fail. This commit adds the function back.